### PR TITLE
Allow HTTPS_MODE to be set in configuration file

### DIFF
--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -54,7 +54,7 @@ FQDN = getfqdn()
 # enabled = Use HTTPS only in all URLs and mDNS adverts
 # disabled = Use HTTP only in all URLs and mDNS adverts
 # mixed = Use HTTP in all URLs, but additionally advertise an HTTPS endpoint for discovery of this API only
-HTTPS_MODE = 'disabled'
+HTTPS_MODE = nmoscommonconfig.config.get('https_mode', 'disabled')
 
 def updateHost () :
     if nmoscommonconfig.config.get('node_hostname') is not None:


### PR DESCRIPTION
I believe this functionality was in ipppython, but has got lost at some point. (It was working for us with the client certificate work).