### PR TITLE
Make compatible with Python 3, test with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ debian/python-nodefacade.substvars
 debian/python-nodefacade*debhelper*
 build/
 debian/files
+
+# Unit testing bits
+.coverage
+*,cover
+.tox
+
+# Python packaging metadata
+*.egg-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.3.0
+- Fixed tests to pass under Python 3
+
+## 0.2.0
+- Added initial repository state

--- a/bin/nmosnode
+++ b/bin/nmosnode
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 
 from gevent import monkey
 monkey.patch_all()
@@ -36,7 +37,7 @@ Node Facade in interactive mode
 Use ^D to exit this console to quit.""")
 
         def _runner():
-            print "Opening Debug console on port {}".format(args.interactive)
+            print("Opening Debug console on port {}".format(args.interactive))
             try:
                 backdoor.serve_forever()
             except:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-python-nodefacade (0.2.0) UNRELEASED; urgency=low
+python-nodefacade (0.3.0) UNRELEASED; urgency=low
 
   * Initial Release
 

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 from nmoscommon.webapi import *
 from urlparse import urlparse, urljoin
 import httplib
@@ -94,7 +96,7 @@ class FacadeAPI(WebAPI):
         headers['Accept'] = 'application/json'
         del headers['Host']
 
-        print "Sending {} request to '{}' with headers={} and data='{}'".format(request.method, href, headers, request.data)
+        print("Sending {} request to '{}' with headers={} and data='{}'".format(request.method, href, headers, request.data))
 
         try:
             resp = requests.request(request.method, href, params=request.args, data=request.data, headers=headers, allow_redirects=True, timeout=30)
@@ -104,7 +106,7 @@ class FacadeAPI(WebAPI):
         if not resp:
             abort(503)
 
-        print resp
+        print(resp)
 
         if resp.status_code/100 != 2:
             abort(resp.status_code)

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -15,8 +15,8 @@
 from __future__ import print_function
 
 from nmoscommon.webapi import *
-from urlparse import urlparse, urljoin
-import httplib
+import six.moves.urllib.parse
+import six.moves.http_client
 import requests
 from nmoscommon.utils import getLocalIP
 from socket import gethostname

--- a/nmosnode/mock_service.py
+++ b/nmosnode/mock_service.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from registry import FacadeRegistry
+from __future__ import absolute_import
+
+from .registry import FacadeRegistry
 import gevent
 
 class MockBackend:

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import gevent
 from gevent import monkey
@@ -28,15 +28,15 @@ import json
 from nmoscommon.httpserver import HttpServer
 from nmoscommon.utils import get_node_id
 from socket import gethostname, getfqdn
-from api import FacadeAPI
-from registry import FacadeRegistry, FacadeRegistryCleaner, legalise_resource
-from serviceinterface import FacadeInterface
+from .api import FacadeAPI
+from .registry import FacadeRegistry, FacadeRegistryCleaner, legalise_resource
+from .serviceinterface import FacadeInterface
 from os import getpid
 from subprocess import check_output
 from systemd import daemon
 
-from api import NODE_APIVERSIONS
-from api import NODE_REGVERSION
+from .api import NODE_APIVERSIONS
+from .api import NODE_REGVERSION
 
 from nmoscommon.utils import getLocalIP
 from nmoscommon.aggregator import Aggregator

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import gevent
 from gevent import monkey
 monkey.patch_all()
@@ -86,7 +88,7 @@ class NodeFacadeService:
         self.aggregator       = Aggregator(self.logger, self.mdns_updater)
 
     def sig_handler(self):
-        print 'Pressed ctrl+c'
+        print('Pressed ctrl+c')
         self.stop()
 
     def sig_hup_handler(self):

--- a/nmosnode/registry.py
+++ b/nmosnode/registry.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 import time, threading, copy
 
 from nmoscommon.logger import Logger
 from nmoscommon import ptptime
 from copy import deepcopy
-from api import NODE_APIVERSIONS
-from api import NODE_REGVERSION
-from api import NODE_APINAMESPACE
-from api import NODE_APINAME
+from .api import NODE_APIVERSIONS
+from .api import NODE_REGVERSION
+from .api import NODE_APINAMESPACE
+from .api import NODE_APINAME
 import re
 import copy
 import json

--- a/nmosnode/registry.py
+++ b/nmosnode/registry.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import time, threading, copy
 
 from nmoscommon.logger import Logger
@@ -490,19 +492,19 @@ class FacadeRegistry(object):
 if __name__ == "__main__":
     import uuid
     registry = FacadeRegistry()
-    print "Registering service and flow"
+    print("Registering service and flow")
     registry.register_service("pipelinemanager", 100, "http://127.0.0.1:12345")
     test_key = str(uuid.uuid4())
     registry.register_resource("pipelinemanager", "flow", test_key, {"label": "test"})
     registry.cleanup_services()
-    print "Find Service:", registry.find_service("flow", test_key)
-    print "Self:", registry.list_self()
-    print "Flows:", registry.list_resource("flow")
-    print "Sources:", registry.list_resource("source")
-    print "Sleeping for", HEARTBEAT_TIMEOUT+1 ,"seconds"
+    print("Find Service:", registry.find_service("flow", test_key))
+    print("Self:", registry.list_self())
+    print("Flows:", registry.list_resource("flow"))
+    print("Sources:", registry.list_resource("source"))
+    print("Sleeping for", HEARTBEAT_TIMEOUT+1 ,"seconds")
     time.sleep(HEARTBEAT_TIMEOUT+1)
     registry.cleanup_services()
     #registry.unregister_service("pipelinemanager", 100)
-    print "Self:", registry.list_self()
-    print "Flows:", registry.list_resource("flow")
-    print "Soures:", registry.list_resource("source")
+    print("Self:", registry.list_self())
+    print("Flows:", registry.list_resource("flow"))
+    print("Soures:", registry.list_resource("source"))

--- a/nmosnode/test_registry.py
+++ b/nmosnode/test_registry.py
@@ -89,16 +89,16 @@ class TestRegistryServices(unittest.TestCase):
 
         # do not allow non-existent services to be removed
         self.assertEqual(registry.RES_NOEXISTS, self.registry.unregister_service("not_there", 1))
-        self.assertItemsEqual(["test_srv_1", "test_srv_2"], self.registry.list_services())
+        six.assertCountEqual(self, ["test_srv_1", "test_srv_2"], self.registry.list_services())
 
         # attempt to remove with wrong pid
         self.assertEqual(registry.RES_UNAUTHORISED, self.registry.unregister_service("test_srv_1", 1))
-        self.assertItemsEqual(["test_srv_1", "test_srv_2"], self.registry.list_services())
+        six.assertCountEqual(self, ["test_srv_1", "test_srv_2"], self.registry.list_services())
 
         # remove one
         self.assertEqual(registry.RES_SUCCESS, self.registry.unregister_service("test_srv_1", 100))
         self.assertNotIn("test_srv_1", self.registry.services)
-        self.assertItemsEqual(["test_srv_2"], self.registry.list_services())
+        six.assertCountEqual(self, ["test_srv_2"], self.registry.list_services())
 
     def test_update_service(self):
         self.registry.register_service("a", "test", 1, "http://a")

--- a/nmosnode/test_registry.py
+++ b/nmosnode/test_registry.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
+import six
 
 import unittest
-import registry
+from . import registry
 import time
 
 # to run: python test_registry.py

--- a/nmosnode/test_registry.py
+++ b/nmosnode/test_registry.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import unittest
 import registry
 import time
@@ -147,7 +149,7 @@ class TestRegistry(unittest.TestCase):
         """Registering a resource adds a 'node_id' property to the resource"""
         self.registry.register_resource("a", 1, "device", "device_a_key", {"label": "device_a"})
         service_resources = self.registry.list_resource("device")
-        print service_resources
+        print(service_resources)
         self.assertEqual("test_node_id", service_resources["device_a_key"]["node_id"])
 
     def test_register_calls_aggregator(self):

--- a/setup.py
+++ b/setup.py
@@ -33,34 +33,6 @@ back-end data providers.
 """
 
 
-def check_packages(packages):
-    failure = False
-    for python_package, package_details in packages:
-        try:
-            __import__(python_package)
-        except ImportError as err:
-            failure = True
-            print("Cannot find", python_package,)
-            print("you need to install :", package_details)
-
-    return not failure
-
-
-def check_dependencies(packages):
-    failure = False
-    for python_package, dependency_filename, dependency_url in packages:
-        try:
-            __import__(python_package)
-        except ImportError as err:
-            failure = True
-            print()
-            print("Cannot find", python_package,)
-            print("you need to install :", dependency_filename)
-            print("... originally retrieved from", dependency_url)
-
-    return not failure
-
-
 def is_package(path):
     return (
         os.path.isdir(path) and

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ packages = find_packages(".")
 package_names = packages.keys()
 
 packages_required = [
-    "nmoscommon"
+    "nmoscommon",
+    "six"
 ]
 
 deps_required = []

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 
 # Basic metadata
 name = "python-nodefacade"
-version = "0.1.0"
+version = "0.3.0"
 description = "nmos node API"
 url = "www.nmos.tv"
 author = "Peter Brightwell"

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,18 @@ from distutils.version import LooseVersion
 import os
 import sys
 
+# Basic metadata
+name = "python-nodefacade"
+version = "0.1.0"
+description = "nmos node API"
+url = "www.nmos.tv"
+author = "Peter Brightwell"
+author_email = "peter.brightwell@bbc.co.uk"
+licence = "Apache 2"
+long_description = """
+Package providing a basic NMOS Node API implementation. The API is provided as a facade which accepts data from private back-end data providers.
+"""
+
 def check_packages(packages):
     failure = False
     for python_package, package_details in packages:
@@ -75,22 +87,19 @@ packages_required = [
 
 deps_required = []
 
-setup(name = "python-nodefacade",
-      version = "0.1.0",
-      description = "nmos node API",
-      url='www.nmos.tv',
-      author='Peter Brightell',
-      author_email='peter.brightwell@bbc.co.uk',
-      license='Apache 2',
-      packages = package_names,
-      package_dir = packages,
-      install_requires = packages_required,
-      scripts = [
-                ],
+setup(name=name,
+      version=version,
+      description=description,
+      url=url,
+      author=author,
+      author_email=author_email,
+      license=licence,
+      packages=package_names,
+      package_dir=packages,
+      install_requires=packages_required,
+      scripts=[],
       data_files=[
           ('/usr/bin', ['bin/nmosnode'])
       ],
-      long_description = """
-Package providing a basic NMOS Node API implementation. The API is provided as a facade which accepts data from private back-end data providers.
-"""
+      long_description=long_description
       )

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,7 @@
 
 
 from setuptools import setup
-from distutils.version import LooseVersion
 import os
-import sys
 
 # Basic metadata
 name = "python-nodefacade"
@@ -29,8 +27,10 @@ author = "Peter Brightwell"
 author_email = "peter.brightwell@bbc.co.uk"
 licence = "Apache 2"
 long_description = """
-Package providing a basic NMOS Node API implementation. The API is provided as a facade which accepts data from private back-end data providers.
+Package providing a basic NMOS Node API implementation. The API is provided as a facade which accepts data from private
+back-end data providers.
 """
+
 
 def check_packages(packages):
     failure = False
@@ -43,6 +43,7 @@ def check_packages(packages):
             print "you need to install :", package_details
 
     return not failure
+
 
 def check_dependencies(packages):
     failure = False
@@ -58,18 +59,20 @@ def check_dependencies(packages):
 
     return not failure
 
+
 def is_package(path):
     return (
         os.path.isdir(path) and
         os.path.isfile(os.path.join(path, '__init__.py'))
         )
 
-def find_packages(path, base="" ):
+
+def find_packages(path, base=""):
     """ Find all packages in path """
     packages = {}
     for item in os.listdir(path):
         dir = os.path.join(path, item)
-        if is_package( dir ):
+        if is_package(dir):
             if base:
                 module_name = "%(base)s.%(item)s" % vars()
             else:
@@ -77,6 +80,7 @@ def find_packages(path, base="" ):
             packages[module_name] = dir
             packages.update(find_packages(dir, module_name))
     return packages
+
 
 packages = find_packages(".")
 package_names = packages.keys()

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import print_function
 from setuptools import setup
 import os
 
@@ -39,8 +40,8 @@ def check_packages(packages):
             __import__(python_package)
         except ImportError as err:
             failure = True
-            print "Cannot find", python_package,
-            print "you need to install :", package_details
+            print("Cannot find", python_package,)
+            print("you need to install :", package_details)
 
     return not failure
 
@@ -52,10 +53,10 @@ def check_dependencies(packages):
             __import__(python_package)
         except ImportError as err:
             failure = True
-            print
-            print "Cannot find", python_package,
-            print "you need to install :", dependency_filename
-            print "... originally retrieved from", dependency_url
+            print()
+            print("Cannot find", python_package,)
+            print("you need to install :", dependency_filename)
+            print("... originally retrieved from", dependency_url)
 
     return not failure
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py3
+
+[testenv]
+commands = nose2 --with-coverage --coverage-report=annotate --coverage-report=term --coverage=nmosnode
+deps =
+    nose2
+    mock


### PR DESCRIPTION
Makes nmos-node compatible with Python 3 (using six where necessary).

Doesn't yet build a Debian package or RPM for Python 3 - that's still work in progress.