### PR TITLE
Fix build and Deb packaging issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
         booleanParam(name: "FORCE_DEBUPLOAD", defaultValue: false, description: "Force Debian package upload")
     }
     triggers {
-        upstream (upstreamProjects: "ap.python-library-nmos-common")
+        upstream (upstreamProjects: "apmm-repos/nmos-common/master")
     }
     environment {
         http_proxy = "http://www-cache.rd.bbc.co.uk:8080"

--- a/Makefile
+++ b/Makefile
@@ -81,16 +81,16 @@ deb: source deb_dist $(DEBIANOVERRIDES)
 
 # START OF RPM SPEC RULES
 # If you have your own rpm spec file to use you'll need to disable these rules
-$(RPM_PREFIX)/$(MODNAME).spec: rpm_spec
-
-rpm_spec: $(topdir)/setup.py
-	$(PYTHON3) $(topdir)/setup.py bdist_rpm $(RPM_PARAMS) --spec-only --dist-dir=$(RPM_PREFIX)
+#$(RPM_PREFIX)/$(MODNAME).spec: rpm_spec
+#
+#rpm_spec: $(topdir)/setup.py
+#	$(PYTHON3) $(topdir)/setup.py bdist_rpm $(RPM_PARAMS) --spec-only --dist-dir=$(RPM_PREFIX)
 # END OF RPM SPEC RULES
 
 $(RPMBUILDDIRS):
 	mkdir -p $@
 
-$(RPM_PREFIX)/SPECS/$(MODNAME).spec: $(RPM_PREFIX)/$(MODNAME).spec $(RPM_PREFIX)/SPECS
+$(RPM_PREFIX)/SPECS/$(MODNAME).spec: $(topdir)/rpm/$(MODNAME).spec $(RPM_PREFIX)/SPECS
 	rm -rf $@
 	cp -f $< $@
 

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ test:
 
 deb_dist: $(topbuilddir)/dist/$(MODNAME)-$(VERSION).tar.gz
 	$(PY2DSC) --with-python2=true $(topbuilddir)/dist/$(MODNAME)-$(VERSION).tar.gz
+	sed -i 's/--with/--with apache2 --with systemd --with/' deb_dist/$(DEBNAME)-$(DEBVERSION)/debian/rules
 
 $(DEBIANDIR)/%: $(topdir)/debian/% deb_dist
 	cp $< $@
@@ -75,7 +76,6 @@ dsc: deb_dist $(DEBIANOVERRIDES)
 
 deb: source deb_dist $(DEBIANOVERRIDES)
 	DEB_BUILD_OPTIONS=nocheck
-	sed -i 's/--with/--with apache2 --with systemd --with/' deb_dist/$(DEBNAME)-$(DEBVERSION)/debian/rules
 	cd $(DEBIANDIR)/..;debuild -uc -us
 	cp $(topbuilddir)/deb_dist/python*$(DEBNAME)_$(DEBVERSION)-1*.deb $(topbuilddir)/dist
 

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ dsc: deb_dist $(DEBIANOVERRIDES)
 
 deb: source deb_dist $(DEBIANOVERRIDES)
 	DEB_BUILD_OPTIONS=nocheck
+	sed -i 's/--with/--with apache2 --with systemd --with/' deb_dist/$(DEBNAME)-$(DEBVERSION)/debian/rules
 	cd $(DEBIANDIR)/..;debuild -uc -us
 	cp $(topbuilddir)/deb_dist/python*$(DEBNAME)_$(DEBVERSION)-1*.deb $(topbuilddir)/dist
 

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ $(RPM_PREFIX)/SOURCES/$(MODNAME)-$(VERSION).tar.gz: $(topbuilddir)/dist/$(MODNAM
 rpm_dirs: $(RPMBUILDDIRS) $(RPM_PREFIX)/SPECS/$(MODNAME).spec $(RPM_PREFIX)/SOURCES/$(MODNAME)-$(VERSION).tar.gz
 
 rpm: $(RPM_PREFIX)/SPECS/$(MODNAME).spec $(RPM_PREFIX)/SOURCES/$(MODNAME)-$(VERSION).tar.gz $(RPMBUILDDIRS)
+	cp $(topdir)/rpm/*.service $(topdir)/rpm/*.conf $(topbuilddir)/build/rpm/SOURCES
 	rpmbuild -ba --define '_topdir $(RPM_PREFIX)' --clean $<
 	cp $(RPM_PREFIX)/RPMS/*/*.rpm $(topbuilddir)/dist
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -24,7 +24,6 @@ case "$1" in
         chown -R ipstudio:ipstudio /var/nmos-node
         chmod a+rwx /var/nmos-node
         usermod -aG adm ipstudio # Necessary for lldpcli
-        service apache2 reload
 	;;
 
 

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,3 +1,0 @@
-systemctl stop ips-nodefacade || true
-
-#DEBHELPER#

--- a/debian/python-nodefacade.service
+++ b/debian/python-nodefacade.service
@@ -12,5 +12,4 @@ ExecStart=/usr/bin/nmosnode
 
 [Install]
 WantedBy=multi-user.target
-Alias=nmos-node.service
-Alias=ips-nodefacade.service
+Alias=nmos-node.service ips-nodefacade.service

--- a/rpm/nodefacade.spec
+++ b/rpm/nodefacade.spec
@@ -56,10 +56,10 @@ rm -rf %{buildroot}
 %files
 %{_bindir}/nmosnode
 
-%{_unitdir}/ips-nodefacade.service
+%{_unitdir}/%{name}.service
 
-%{python2_sitelib}/nmosnode
-%{python2_sitelib}/python_nodefacade-%{version}*.egg-info
+%{python2_sitelib}/%{module_name}
+%{python2_sitelib}/%{module_name}-%{version}*.egg-info
 
 %defattr(-,ipstudio, ipstudio,-)
 %config %{_sysconfdir}/httpd/conf.d/ips-apis/ips-api-node.conf

--- a/rpm/nodefacade.spec
+++ b/rpm/nodefacade.spec
@@ -1,7 +1,7 @@
 %global module_name nodefacade
 
 Name: 			python-%{module_name}
-Version: 		0.3.4
+Version: 		0.3.5
 Release: 		2%{?dist}
 License: 		Internal Licence
 Summary: 		Provides the ipstudio node facade service

--- a/rpm/nodefacade.spec
+++ b/rpm/nodefacade.spec
@@ -1,10 +1,12 @@
-Name: 			python-nodefacade
-Version: 		0.1.0
+%global module_name nodefacade
+
+Name: 			python-%{module_name}
+Version: 		0.3.4
 Release: 		2%{?dist}
 License: 		Internal Licence
 Summary: 		Provides the ipstudio node facade service
 
-Source0: 		%{name}-%{version}.tar.gz
+Source0: 		%{module_name}-%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -15,7 +17,7 @@ BuildRequires:	systemd
 
 Requires: python
 Requires: ips-reverseproxy-common
-Requires:	nmoscommon
+Requires: nmoscommon
 Requires: systemd-python
 Requires: python2-oauthlib
 %{?systemd_requires}
@@ -24,7 +26,7 @@ Requires: python2-oauthlib
 IS-04 node facade service
 
 %prep
-%setup -n %{name}-%{version}
+%setup -n %{module_name}-%{version}
 
 %build
 %{py2_build}

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 
 # Basic metadata
 name = "nodefacade"
-version = "0.3.4"
+version = "0.3.5"
 description = "nmos node API"
 url = "www.nmos.tv"
 author = "Peter Brightwell"

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,2 +1,3 @@
 [DEFAULT]
 Recommends: lldp, ips-reverseproxy-common, python-mdnsbridge
+Build-Depends: apache2-dev, dh-python, dh-systemd


### PR DESCRIPTION
General lingering packaging issues, however the sed line is worth some extra review. It resolves missing debhelper requirements for the debian/rules file. I could have put a custom rules file into the debian directory, but as py2dsc puts so much stuff into this it didn't feel right. This may or may not be a better approach.