### PR TITLE
registry: fix bottleneck in registering resources

### DIFF
--- a/nmosnode/registry.py
+++ b/nmosnode/registry.py
@@ -460,16 +460,22 @@ class FacadeRegistry(object):
                     ))
         return response
 
+    def _len_resource(self, type):
+        response = 0
+        for name in self.services:
+            response += len(self.services[name]["resource"][type])
+        return response
+
     def _update_mdns(self, type):
-        items = self.list_resource(type)
-        if not isinstance(items, dict):
-            return
-        if len(items) == 1:
+        if not type in self.permitted_resources:
+            return RES_UNSUPPORTED
+        num_items = self._len_resource(type)
+        if num_items == 1:
             try:
                 self.mdns_updater.update_mdns(type, "register")
             except Exception:
                 self.mdns_updater.update_mdns(type, "update")
-        elif len(items) == 0:
+        elif num_items == 0:
             self.mdns_updater.update_mdns(type, "unregister")
         else:
             self.mdns_updater.update_mdns(type, "update")

--- a/rpm/nodefacade.spec
+++ b/rpm/nodefacade.spec
@@ -1,7 +1,7 @@
 %global module_name nodefacade
 
 Name: 			python-%{module_name}
-Version: 		0.3.7
+Version: 		0.3.8
 Release: 		2%{?dist}
 License: 		Internal Licence
 Summary: 		Provides the ipstudio node facade service

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 
 # Basic metadata
 name = "nodefacade"
-version = "0.3.7"
+version = "0.3.8"
 description = "nmos node API"
 url = "www.nmos.tv"
 author = "Peter Brightwell"


### PR DESCRIPTION
A historic case of not thinking it through. Every time a resource was registered with the Node API it enumerated a full dictionary of all resources of that type. All that was necessary was to check how many there were. This avoids registrations getting progressively slower.