### PR TITLE
Add provisional support for v1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Node API Implementation Changelog
 
+## 0.5.0
+- Add provisional support for IS-04 v1.3
+
 ## 0.4.3
 - Update method used to access config file
 

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -22,7 +22,7 @@ from socket import gethostname
 
 from nmoscommon.nmoscommonconfig import config as _config
 
-NODE_APIVERSIONS = ["v1.0", "v1.1", "v1.2"]
+NODE_APIVERSIONS = ["v1.0", "v1.1", "v1.2", "v1.3"]
 NODE_REGVERSION = _config.get('nodefacade', {}).get('NODE_REGVERSION', 'v1.2')
 NODE_APINAMESPACE = "x-nmos"
 NODE_APINAME = "node"

--- a/rpm/nodefacade.spec
+++ b/rpm/nodefacade.spec
@@ -1,7 +1,7 @@
 %global module_name nodefacade
 
 Name: 			python-%{module_name}
-Version: 		0.4.3
+Version: 		0.5.0
 Release: 		2%{?dist}
 License: 		Internal Licence
 Summary: 		Provides the ipstudio node facade service

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 
 # Basic metadata
 name = "nodefacade"
-version = "0.4.3"
+version = "0.5.0"
 description = "BBC implementation of an AMWA NMOS Node API"
 url = "https://github.com/bbc/nmos-node"
 author = "Peter Brightwell"


### PR DESCRIPTION
Adds v1.3 API endpoints and mDNS announcements, but won't handle downgrades properly yet as the schemas for v1.3 have not been tied down.