### PR TITLE
 Use prefer_hostnames/node_hostname in controls and manifest_href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Node API Implementation Changelog
 
+## 0.9.0
+- Use nmoscommon prefer_hostnames/node_hostname to inform all absolute hrefs
+
 ## 0.8.3
 - Added linting stage to CI and .flake8 file, fixed linting
 

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -62,6 +62,8 @@ ENABLE_P2P = _config.get('node_p2p_enable', True)
 def updateHost():
     if _config.get('node_hostname') is not None:
         return _config.get('node_hostname')
+    elif _config.get('prefer_hostnames', False) is True:
+        return FQDN
     elif _config.get('prefer_ipv6', False) is False:
         return getLocalIP()
     else:

--- a/nmosnode/registry.py
+++ b/nmosnode/registry.py
@@ -440,6 +440,20 @@ class FacadeRegistry(object):
             return RES_NOEXISTS
         return self.services[name]["type"]
 
+    def preprocess_url(self, url):
+        parsed_url = urlparse(url)
+        scheme = parsed_url.scheme
+        if HTTPS_MODE == "enabled":
+            if scheme == "http":
+                scheme = "https"
+            elif scheme == "ws":
+                scheme = "wss"
+        netloc = self.node_data["host"]
+        if parsed_url.port:
+            netloc += ":{}".format(parsed_url.port)
+        parsed_url = parsed_url._replace(netloc=netloc, scheme=scheme)
+        return urlunparse(parsed_url)
+
     def preprocess_resource(self, type, key, value, api_version="v1.0"):
         if type == "device":
             value_copy = copy.deepcopy(value)
@@ -448,31 +462,12 @@ class FacadeRegistry(object):
                     value_copy["controls"] = value_copy["controls"] + list(self.services[name]["control"][key].values())
             if "controls" in value_copy:
                 for control in value_copy["controls"]:
-                    parsed_url = urlparse(control["href"])
-                    scheme = parsed_url.scheme
-                    if HTTPS_MODE == "enabled":
-                        if scheme == "http":
-                            scheme = "https"
-                        elif scheme == "ws":
-                            scheme = "wss"
-                    netloc = self.node_data["host"]
-                    if parsed_url.port:
-                        netloc += ":{}".format(parsed_url.port)
-                    parsed_url = parsed_url._replace(netloc=netloc, scheme=scheme)
-                    control["href"] = urlunparse(parsed_url)
+                    control["href"] = self.preprocess_url(control["href"])
             return legalise_resource(value_copy, type, api_version)
         elif type == "sender":
             value_copy = copy.deepcopy(value)
             if "manifest_href" in value_copy:
-                parsed_url = urlparse(value_copy["manifest_href"])
-                scheme = parsed_url.scheme
-                if HTTPS_MODE == "enabled":
-                    scheme = "https"
-                netloc = self.node_data["host"]
-                if parsed_url.port:
-                    netloc += ":{}".format(parsed_url.port)
-                parsed_url = parsed_url._replace(netloc=netloc, scheme=scheme)
-                value_copy["manifest_href"] = urlunparse(parsed_url)
+                value_copy["manifest_href"] = self.preprocess_url(value_copy["manifest_href"])
             return legalise_resource(value_copy, type, api_version)
         else:
             return legalise_resource(value, type, api_version)

--- a/rpm/nodefacade.spec
+++ b/rpm/nodefacade.spec
@@ -1,7 +1,7 @@
 %global module_name nodefacade
 
 Name: 			python-%{module_name}
-Version: 		0.8.3
+Version: 		0.9.0
 Release: 		2%{?dist}
 License: 		Internal Licence
 Summary: 		Provides the ipstudio node facade service

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 
 # Basic metadata
 name = "nodefacade"
-version = "0.8.3"
+version = "0.9.0"
 description = "BBC implementation of an AMWA NMOS Node API"
 url = "https://github.com/bbc/nmos-node"
 author = "Peter Brightwell"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -172,14 +172,16 @@ class TestRegistry(unittest.TestCase):
         registry.HTTPS_MODE = "disabled"
         self.registry.register_resource("a", 1, "sender", "sender_a_key", {"manifest_href": "http://some-url.com"})
         sender_resources = self.registry.list_resource("sender")
-        self.assertEqual(sender_resources["sender_a_key"]["manifest_href"], "http://some-url.com")
+        scheme = sender_resources["sender_a_key"]["manifest_href"].split("://")[0]
+        self.assertEqual(scheme, "http")
 
     def test_sender_manifest_returns_https(self):
         """Check that Sender manifest_href is modified in HTTPS mode"""
         registry.HTTPS_MODE = "enabled"
         self.registry.register_resource("a", 1, "sender", "sender_a_key", {"manifest_href": "http://some-url.com"})
         sender_resources = self.registry.list_resource("sender")
-        self.assertEqual(sender_resources["sender_a_key"]["manifest_href"], "https://some-url.com")
+        scheme = sender_resources["sender_a_key"]["manifest_href"].split("://")[0]
+        self.assertEqual(scheme, "https")
 
     def test_device_controls_return_http(self):
         """Check that Device control hrefs are unmodified in HTTP mode"""
@@ -191,7 +193,7 @@ class TestRegistry(unittest.TestCase):
         device_resources = self.registry.list_resource("device", "v1.2")
         self.assertEqual(len(controls), len(device_resources["device_a_key"]["controls"]))
         for control in device_resources["device_a_key"]["controls"]:
-            self.assertIn(control["href"].split(":")[0], ["http", "ws"])
+            self.assertIn(control["href"].split("://")[0], ["http", "ws"])
 
     def test_device_controls_return_https(self):
         """Check that Device control hrefs are modified in HTTPS mode"""
@@ -203,7 +205,7 @@ class TestRegistry(unittest.TestCase):
         device_resources = self.registry.list_resource("device", "v1.2")
         self.assertEqual(len(controls), len(device_resources["device_a_key"]["controls"]))
         for control in device_resources["device_a_key"]["controls"]:
-            self.assertIn(control["href"].split(":")[0], ["https", "wss"])
+            self.assertIn(control["href"].split("://")[0], ["https", "wss"])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I think it's questionable whether this really belongs in the Node API implementation, but as it's how we've already handled the Node 'services' array I'm just completing the picture. In time we may need to move this URL wrangling into the individual contributing services.