### PR TITLE
Addition of oauth client to nmos-node

### DIFF
--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -351,8 +351,7 @@ class Aggregator(object):
             self.auth_registry.register_client(client_name=client_name, client_uri=client_uri)
             # Extract the 'RemoteApp' class created when registering
             self.auth_client = getattr(self.auth_registry, client_name)
-
-            print("registered redirect_uri: " + self.auth_registrar.redirect_uri)
+            # Fetch Token
             self.fetch_auth_token()
 
     def fetch_auth_token(self):
@@ -360,7 +359,7 @@ class Aggregator(object):
             if "authorization_code" in self.auth_registrar.allowed_grant:
                 import webbrowser
                 webbrowser.open("http://localhost/x-nmos/node/login")
-            if "client_credentials" in self.auth_registrar.allowed_grant:
+            elif "client_credentials" in self.auth_registrar.allowed_grant:
                 # Fetch Token
                 token = self.auth_client.fetch_access_token()
                 # Store token in member variable to be extracted using `fetch_local_token` function

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -16,21 +16,20 @@ from gevent import monkey
 monkey.patch_all()
 from gevent import sleep, queue, spawn  # noqa E402
 
-from six import itervalues # noqa E402
-from six.moves.urllib.parse import urljoin # noqa E402
 import requests # noqa E402
 import json # noqa E402
 import time # noqa E402
 import traceback # noqa E402
-from authlib.oauth2.rfc6750 import InvalidTokenError
+from six import itervalues # noqa E402
+from six.moves.urllib.parse import urljoin # noqa E402
+from authlib.oauth2.rfc6750 import InvalidTokenError # noqa E402
 
-from nmoscommon.logger import Logger # noqa E402
 from mdnsbridge.mdnsbridgeclient import IppmDNSBridge # noqa E402
+from nmoscommon.logger import Logger # noqa E402
 from nmoscommon.mdns.mdnsExceptions import ServiceNotFoundException # noqa E402
 from nmoscommon.nmoscommonconfig import config as _config # noqa E402
 
-from .authclient import AuthRegistrar
-from .authclient import AuthRegistry
+from .authclient import AuthRegistrar, AuthRegistry # noqa E402
 
 auth_registry = AuthRegistry()  # Set globally to allow for initialisation in api.py
 

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -355,7 +355,8 @@ class Aggregator(object):
                     # Register Node Client
                     self.auth_registry.register_client(client_name=client_name, client_uri=client_uri)
                 except (OSError, IOError):
-                    self.logger.writeError("Exception accessing OAuth credentials. Could not register OAuth2 client.")
+                    self.logger.writeError(
+                        "Exception accessing OAuth credentials. This may be a file permissions issue.")
                     return
                 # Extract the 'RemoteApp' class created when registering
                 self.auth_client = getattr(self.auth_registry, client_name)

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -25,7 +25,7 @@ from six import itervalues # noqa E402
 from six.moves.urllib.parse import urljoin # noqa E402
 from socket import getfqdn  # noqa E402
 from authlib.oauth2.rfc6750 import InvalidTokenError # noqa E402
-from authlib.oauth2.base import OAuth2Error # noqa E402
+from authlib.oauth2 import OAuth2Error # noqa E402
 
 from mdnsbridge.mdnsbridgeclient import IppmDNSBridge # noqa E402
 from nmoscommon.logger import Logger # noqa E402
@@ -34,9 +34,14 @@ from nmoscommon.nmoscommonconfig import config as _config # noqa E402
 
 from .authclient import AuthRegistrar # noqa E402
 
-AGGREGATOR_APIVERSION = _config.get('nodefacade').get('NODE_REGVERSION')
-AGGREGATOR_APINAMESPACE = "x-nmos"
+APINAMESPACE = "x-nmos"
+
 AGGREGATOR_APINAME = "registration"
+AGGREGATOR_APIVERSION = _config.get('nodefacade').get('NODE_REGVERSION')
+AGGREGATOR_APIROOT = '/' + APINAMESPACE + '/' + AGGREGATOR_APINAME + '/'
+
+NODE_APINAME = "node"
+NODE_APIROOT = '/' + APINAMESPACE + '/' + NODE_APINAME + '/'
 
 LEGACY_REG_MDNSTYPE = "nmos-registration"
 REGISTRATION_MDNSTYPE = "nmos-register"
@@ -44,10 +49,6 @@ REGISTRATION_MDNSTYPE = "nmos-register"
 OAUTH_MODE = _config.get("oauth_mode", False)
 ALLOWED_GRANTS = ["authorization_code", "refresh_token", "client_credentials"]
 ALLOWED_SCOPE = "is-04"
-
-NODE_APINAMESPACE = "x-nmos"
-NODE_APINAME = "node"
-NODE_APIROOT = NODE_APINAMESPACE + '/' + NODE_APINAME + '/'
 
 
 class NoAggregator(Exception):
@@ -365,7 +366,7 @@ class Aggregator(object):
             try:
                 if "authorization_code" in self.auth_registrar.allowed_grant:
                     # Open browser at endpoint for redirecting to Auth Server's /authorize endpoint
-                    webbrowser.open("http://" + getfqdn() + "/x-nmos/node/login")
+                    webbrowser.open("http://" + getfqdn() + NODE_APIROOT + "login")
                 elif "client_credentials" in self.auth_registrar.allowed_grant:
                     # Fetch Token
                     token = self.auth_client.fetch_access_token()
@@ -380,7 +381,7 @@ class Aggregator(object):
         """Register OAuth client with Authorization Server"""
         auth_registrar = AuthRegistrar(
             client_name=client_name,
-            redirect_uri='http://' + getfqdn() + '/x-nmos/node/authorize',
+            redirect_uri='http://' + getfqdn() + NODE_APIROOT + 'authorize',
             client_uri=client_uri,
             allowed_scope=ALLOWED_SCOPE,
             allowed_grant=ALLOWED_GRANTS
@@ -401,7 +402,7 @@ class Aggregator(object):
             data = json.dumps(data)
             headers.update({"Content-Type": "application/json"})
 
-        url = AGGREGATOR_APINAMESPACE + "/" + AGGREGATOR_APINAME + "/" + AGGREGATOR_APIVERSION + url
+        url = AGGREGATOR_APIROOT + AGGREGATOR_APIVERSION + url
         for i in range(0, 3):
             if self.aggregator == "":
                 self.logger.writeWarning("No aggregator available on the network or mdnsbridge unavailable")

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -350,7 +350,7 @@ class Aggregator(object):
             try:
                 # Register Node Client
                 self.auth_registry.register_client(client_name=client_name, client_uri=client_uri)
-            except OSError:
+            except (OSError, IOError):
                 self.logger.writeError("Exception accessing OAuth credentials. Could not register OAuth2 client.")
             # Extract the 'RemoteApp' class created when registering
             self.auth_client = getattr(self.auth_registry, client_name)

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -20,8 +20,10 @@ import requests # noqa E402
 import json # noqa E402
 import time # noqa E402
 import traceback # noqa E402
+import webbrowser  # noqa E402
 from six import itervalues # noqa E402
 from six.moves.urllib.parse import urljoin # noqa E402
+from socket import getfqdn  # noqa E402
 from authlib.oauth2.rfc6750 import InvalidTokenError # noqa E402
 
 from mdnsbridge.mdnsbridgeclient import IppmDNSBridge # noqa E402
@@ -357,8 +359,7 @@ class Aggregator(object):
     def fetch_auth_token(self):
         if self.auth_client is not None and self.auth_registry is not None:
             if "authorization_code" in self.auth_registrar.allowed_grant:
-                import webbrowser
-                webbrowser.open("http://localhost/x-nmos/node/login")
+                webbrowser.open("http://" + getfqdn() + "/x-nmos/node/login")
             elif "client_credentials" in self.auth_registrar.allowed_grant:
                 # Fetch Token
                 token = self.auth_client.fetch_access_token()
@@ -371,7 +372,7 @@ class Aggregator(object):
             client_name=client_name,
             client_uri=client_uri,
             allowed_scope="is-04",
-            redirect_uri='http://localhost/x-nmos/node/authorize',
+            redirect_uri='http://' + getfqdn() + '/x-nmos/node/authorize',
             allowed_grant="client_credentials\nauthorization_code",
             allowed_response="code",
             auth_method="client_secret_basic"

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -340,7 +340,7 @@ class Aggregator(object):
     def register_auth_client(self, node_object):
         """Function for Registering OAuth client with Auth Server and instantiating OAuth Client class"""
         client_name = node_object['data']['description']
-        client_uri = node_object['data']['href']
+        client_uri = 'http://' + node_object['data']['label']
 
         if OAUTH_MODE is True and self.auth_registrar is None:
             self.auth_registrar = self._auth_register(

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -34,16 +34,13 @@ from nmoscommon.logger import Logger # noqa E402
 from nmoscommon.mdns.mdnsExceptions import ServiceNotFoundException # noqa E402
 from nmoscommon.nmoscommonconfig import config as _config # noqa E402
 
+from .api import NODE_APIROOT # noqa E402
 from .authclient import AuthRegistrar # noqa E402
 
 APINAMESPACE = "x-nmos"
-
 AGGREGATOR_APINAME = "registration"
 AGGREGATOR_APIVERSION = _config.get('nodefacade').get('NODE_REGVERSION')
 AGGREGATOR_APIROOT = '/' + APINAMESPACE + '/' + AGGREGATOR_APINAME + '/'
-
-NODE_APINAME = "node"
-NODE_APIROOT = '/' + APINAMESPACE + '/' + NODE_APINAME + '/'
 
 LEGACY_REG_MDNSTYPE = "nmos-registration"
 REGISTRATION_MDNSTYPE = "nmos-register"
@@ -261,6 +258,9 @@ class Aggregator(object):
         try:
             self.logger.writeDebug("Clearing old Node from API prior to re-registration")
             self._SEND("DELETE", "/resource/nodes/" + self._registered["node"]["data"]["id"])
+        except OAuth2Error as e:
+            self.logger.writeInfo("Invalid Request due to lack of Authorization. {}".format(e))
+            return
         except InvalidRequest as e:
             # 404 etc is ok
             self.logger.writeInfo("Invalid request when deleting Node prior to registration: {}".format(e))

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -352,6 +352,7 @@ class Aggregator(object):
                 self.auth_registry.register_client(client_name=client_name, client_uri=client_uri)
             except (OSError, IOError):
                 self.logger.writeError("Exception accessing OAuth credentials. Could not register OAuth2 client.")
+                return
             # Extract the 'RemoteApp' class created when registering
             self.auth_client = getattr(self.auth_registry, client_name)
             # Fetch Token
@@ -435,6 +436,8 @@ class Aggregator(object):
                             except Exception as e:
                                 self.logger.writeError("Error re-requesting token: {}. Removing Auth Client".format(e))
                                 self.auth_client = None
+                        except OAuth2Error as e:
+                            self.logger.writeError("Failed to fetch token before making API call. Error: {}".format(e))
 
                 if R is None:
                     # Try another aggregator

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -66,7 +66,7 @@ class FacadeAPI(WebAPI):
 
     @route(NODE_APIROOT + "login", auto_json=False)
     def login(self):
-        """Redirect to Auth Server for authorization"""
+        """Redirect to Auth Server's authorization endpoint"""
         redirect_uri = url_for('_authorization', _external=True)
         self.auth_client = getattr(self.auth_registry, self.auth_registry.client_name)
         return self.auth_client.authorize_redirect(redirect_uri)

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -22,7 +22,7 @@ import requests
 from socket import gethostname
 
 from nmoscommon.nmoscommonconfig import config as _config
-from .auth_client import OAUTH
+from .aggregator import auth_registry
 
 NODE_APIVERSIONS = ["v1.0", "v1.1", "v1.2", "v1.3"]
 if _config.get("https_mode", "disabled") == "enabled":
@@ -40,7 +40,7 @@ class FacadeAPI(WebAPI):
         self.registry = registry
         self.node_id = registry.node_id
         super(FacadeAPI, self).__init__()
-        OAUTH.init_app(self.app)
+        auth_registry.init_app(self.app)
 
     @route('/')
     def root(self):

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -14,23 +14,25 @@
 
 from __future__ import print_function
 
-from os import urandom
-from flask import request, url_for, redirect
-from nmoscommon.webapi import WebAPI, route, resource_route, abort
-from six.moves.urllib.parse import urljoin
-from six import itervalues
 import requests
+from os import urandom
 from socket import gethostname
+from flask import request, url_for, redirect
+from six import itervalues
+from six.moves.urllib.parse import urljoin
 
+from nmoscommon.webapi import WebAPI, route, resource_route, abort
 from nmoscommon.nmoscommonconfig import config as _config
 
 NODE_APIVERSIONS = ["v1.0", "v1.1", "v1.2", "v1.3"]
 if _config.get("https_mode", "disabled") == "enabled":
     NODE_APIVERSIONS.remove("v1.0")
 NODE_REGVERSION = _config.get('nodefacade', {}).get('NODE_REGVERSION', 'v1.2')
+
 NODE_APINAMESPACE = "x-nmos"
 NODE_APINAME = "node"
 NODE_APIROOT = '/' + NODE_APINAMESPACE + '/' + NODE_APINAME + '/'
+
 HOSTNAME = gethostname().split(".", 1)[0]
 RESOURCE_TYPES = ["sources", "flows", "devices", "senders", "receivers"]
 

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -19,7 +19,7 @@ from nmoscommon.webapi import WebAPI, route, resource_route, abort
 from six.moves.urllib.parse import urljoin
 from six import itervalues
 import requests
-from socket import gethostname
+from socket import gethostname, getfqdn
 
 from nmoscommon.nmoscommonconfig import config as _config
 from .aggregator import auth_registry
@@ -42,6 +42,7 @@ class FacadeAPI(WebAPI):
         super(FacadeAPI, self).__init__()
         auth_registry.init_app(self.app)
         self.app.config["SECRET_KEY"] = "secret"
+        self.app.config["SERVER_NAME"] = getfqdn()
         self.client = None
 
     @route('/')
@@ -65,6 +66,8 @@ class FacadeAPI(WebAPI):
     @route(NODE_APIROOT + "login", auto_json=False)
     def login(self):
         redirect_uri = url_for('_authorization', _external=True)
+        print(redirect_uri)
+        print(auth_registry.client_uri + 'x-nmos/node/authorize')
         self.client = getattr(auth_registry, auth_registry.client_name)
         return self.client.authorize_redirect(redirect_uri)
 

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -22,6 +22,7 @@ import requests
 from socket import gethostname
 
 from nmoscommon.nmoscommonconfig import config as _config
+from .auth_client import OAUTH
 
 NODE_APIVERSIONS = ["v1.0", "v1.1", "v1.2", "v1.3"]
 if _config.get("https_mode", "disabled") == "enabled":
@@ -39,6 +40,7 @@ class FacadeAPI(WebAPI):
         self.registry = registry
         self.node_id = registry.node_id
         super(FacadeAPI, self).__init__()
+        OAUTH.init_app(self.app)
 
     @route('/')
     def root(self):

--- a/nmosnode/auth_client.py
+++ b/nmosnode/auth_client.py
@@ -1,0 +1,231 @@
+# Copyright 2019 British Broadcasting Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import json
+import time
+import jwt
+import requests
+from requests.exceptions import HTTPError
+from six.moves.urllib.parse import urljoin
+
+from ..mdnsbridge import IppmDNSBridge
+from ..logger import Logger
+
+NMOSOAUTH_DIR = '/var/nmosoauth'
+CREDENTIALS_FILE = 'oauth_credentials.json'
+CREDENTIALS_PATH = os.path.join(NMOSOAUTH_DIR, CREDENTIALS_FILE)
+
+MDNS_SERVICE_TYPE = "nmos-auth"
+
+API_NAMESPACE = 'x-nmos/auth/v1.0/'
+REGISTRATION_ENDPOINT = API_NAMESPACE + 'register_client'
+TOKEN_ENDPOINT = API_NAMESPACE + 'token'
+
+
+def get_credentials_from_file(file):
+    with open(CREDENTIALS_PATH, 'r') as f:
+        credentials = json.load(f)
+    client_id = credentials['client_id']
+    client_secret = credentials['client_secret']
+    return client_id, client_secret
+
+
+class AuthRegistrar(object):
+    def __init__(self, client_name, redirect_uri, client_uri=None,
+                 allowed_scope=None, allowed_grant="authorization_code",
+                 allowed_response="code", auth_method="client_secret_basic",
+                 certificate=None, logger=None):
+        self.client_name = client_name
+        self.redirect_uri = redirect_uri
+        self.client_uri = client_uri
+        self.allowed_scope = allowed_scope
+        self.allowed_grant = allowed_grant
+        self.allowed_response = allowed_response
+        self.auth_method = auth_method
+        self.certificate = certificate  # Could be deployed centrally for an alternative trust mechanism
+
+        self.client_id = None
+        self.client_secret = None
+        self.logger = Logger("auth_registrar", logger)
+        self.bridge = IppmDNSBridge()
+        self.initialised = self.initialise()
+
+    def initialise(self):
+        try:
+            # Check if credentials file already exists i.e. device is already registered
+            if os.path.isfile(CREDENTIALS_PATH):
+                self.logger.writeWarning("Credentials file already exists. Using existing credentials.")
+                self.client_id, self.client_secret = get_credentials_from_file(CREDENTIALS_PATH)
+            else:
+                self.logger.writeInfo("Registering with Authorization Server...")
+                reg_resp_json = self.send_oauth_registration_request()
+                self.write_credentials_to_file(reg_resp_json, CREDENTIALS_PATH)
+            return True
+        except Exception as e:
+            self.logger.writeError("Unable to initialise OAuth Client with client credentials. {}".format(e))
+            return False
+
+    def write_credentials_to_file(self, data, file_path):
+        self.client_id = data.get('client_id')
+        self.client_secret = data.get('client_secret')
+        credentials = {"client_id": self.client_id, "client_secret": self.client_secret}
+        with open(file_path, 'w') as f:
+            json.dump(credentials, f)
+        os.chmod(file_path, 0o600)
+        return True
+
+    def send_oauth_registration_request(self):
+        try:
+            href = self.bridge.getHref(MDNS_SERVICE_TYPE)
+            registration_href = urljoin(href, REGISTRATION_ENDPOINT)
+            self.logger.writeDebug('Registration endpoint href is: {}'.format(registration_href))
+
+            data = {
+                "client_name": self.client_name,
+                "client_uri": self.client_uri,
+                "scope": self.allowed_scope,
+                "redirect_uri": self.redirect_uri,
+                "grant_type": self.allowed_grant,
+                "response_type": self.allowed_response,
+                "token_endpoint_auth_method": self.auth_method
+            }
+
+            # Decide how Basic Auth details are retrieved - user input? Retrieved from file?
+            reg_resp = requests.post(
+                registration_href,
+                data=data,
+                auth=('dannym', 'password'),
+                timeout=0.5,
+                proxies={'http': ''}
+            )
+            reg_resp.raise_for_status()  # Raise error if status !=201
+            return reg_resp.json()
+        except HTTPError as e:
+            self.logger.writeError("Unable to Register Client with Auth Server. {}".format(e))
+            raise
+
+
+class AuthRequestor(object):
+
+    def __init__(self, auth_registrar=None, logger=None):
+        self.auth_reg = auth_registrar
+        self.bridge = IppmDNSBridge()
+        self.logger = Logger("auth_requestor", logger)
+
+    def token_request_password(self, username, password, scope):
+        """Request Token using Password Grant"""
+        return self.token_request(grant_type="password", username=username, password=password, scope=scope)
+
+    def token_request_code(self, code, scope):
+        """Request Token using Authorization Code Grant"""
+        return self.token_request(grant_type="authorization_code", auth_code=code, scope=scope)
+
+    def token_request(self, grant_type, username=None, password=None, auth_code=None, scope=None):
+        """Determine data object to be sent in Token Request"""
+
+        request_data = None
+
+        if grant_type == "password" and username is not None and password is not None:
+            request_data = {
+                "grant_type": grant_type,
+                "username": username,
+                "password": password
+            }
+        elif grant_type == "authorization_code" and auth_code is not None:
+            if self.auth_reg is not None:
+                request_data = {
+                    "grant_type": grant_type,
+                    "code": auth_code,
+                    "redirect_uri": self.auth_reg.redirect_uri,
+                    "client_id": self.auth_reg.client_id
+                }
+            else:
+                client_id, client_secret = get_credentials_from_file(CREDENTIALS_PATH)
+                request_data = {
+                    "grant_type": grant_type,
+                    "code": auth_code,
+                    "redirect_uri": None,
+                    "client_id": client_id
+                }
+        if request_data is None:
+            raise Exception("Invalid Credentials for the supplied Grant Type")
+
+        if scope is not None:
+            request_data.update({'scope': scope})
+
+        return self._auth_request(request_data)
+
+    def validate_token_expiry(self, bearer_token):
+        """Validate if access token has expired and, if so, remove"""
+        if bearer_token is None:
+            return False
+        else:
+            try:
+                access_token = bearer_token.get('access_token')
+                claims_dict = jwt.decode(access_token, verify=False)
+                expiry_time = claims_dict['exp']
+                current_time = int(time.time())
+                if expiry_time > current_time:
+                    return True
+                else:
+                    self.bearer_token = None
+                    return False
+            except Exception as e:
+                self.logger.writeError("Exception reading Token Expiry: {}. Removing Token.".format(e))
+                return False
+
+    def _auth_request(self, data):
+        """Function for Requesting Bearer Token form Auth Server"""
+        try:
+            href = self.bridge.getHref(MDNS_SERVICE_TYPE)
+            if href == '':
+                raise ValueError("No Services Found of type {}".format(MDNS_SERVICE_TYPE))
+            token_href = urljoin(href, TOKEN_ENDPOINT)
+            client_id, client_secret = get_credentials_from_file(CREDENTIALS_PATH)
+
+            # self.logger.writeDebug('Data is: {}. HREF is: {}. ID is: {}. Secret is: {}'.format(
+            #     data, token_href, client_id, client_secret
+            # ))  # Only for Testing
+
+            bearer_token_req = requests.post(
+                token_href,
+                data=data,
+                auth=(client_id, client_secret),
+                timeout=0.5,
+                proxies={'http': ''}
+            )
+            bearer_token_req.raise_for_status()
+            self.logger.writeInfo("Bearer Token Request Successful")
+            return bearer_token_req.json()
+        except Exception as e:
+            self.logger.writeError("Bearer Token Request Failed. {}".format(e))
+            return False
+
+
+if __name__ == "__main__":  # pragma: no cover
+    auth_reg = AuthRegistrar(
+        client_name="test_oauth_client",
+        client_uri="www.example.com",
+        allowed_scope="is04",
+        redirect_uri="www.app.example.com",
+        allowed_grant="password\nauthorization_code",  # Authlib only accepts grants seperated with newline chars
+        allowed_response="code",
+        auth_method="client_secret_basic",
+        certificate=None
+    )
+    if auth_reg.initialised is True:
+        auth_req = AuthRequestor(auth_reg)
+        token = auth_req.token_request_password(username='dannym', password='password', scope='is04')
+        print('Access Token is: {}'.format(token['access_token']))

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -15,7 +15,6 @@
 import os
 import json
 import requests
-from flask import _app_ctx_stack, current_app
 from requests.exceptions import HTTPError
 from six.moves.urllib.parse import urljoin
 from authlib.flask.client import OAuth

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -127,7 +127,7 @@ class AuthRegistrar(object):
                 proxies={'http': ''}
             )
             reg_resp.raise_for_status()  # Raise error if status !=201
-            self._client_registry[self.client_name] = reg_resp.json()  # Keep a local record of ergistered clients
+            self._client_registry[self.client_name] = reg_resp.json()  # Keep a local record of registered clients
             return reg_resp.json()
         except HTTPError as e:
             logger.writeError("Unable to Register Client with Auth Server. {}".format(e))
@@ -141,6 +141,7 @@ class AuthRegistry(OAuth):
         super(AuthRegistry, self).__init__()
         self.bridge = IppmDNSBridge()
         self.client_name = None
+        self.client_uri = None
         self.bearer_token = None
         self.auth_url = self.bridge.getHref(MDNS_SERVICE_TYPE)
         self.token_url = urljoin(self.auth_url, TOKEN_ENDPOINT)
@@ -160,6 +161,7 @@ class AuthRegistry(OAuth):
     def register_client(self, client_name, client_uri):
         client_id, client_secret = get_credentials_from_file(CREDENTIALS_PATH)
         self.client_name = client_name
+        self.client_uri = client_uri
         return self.register(
             name=client_name,
             client_id=client_id,

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -22,7 +22,7 @@ from authlib.flask.client import OAuth
 from mdnsbridge.mdnsbridgeclient import IppmDNSBridge
 from nmoscommon.logger import Logger
 
-CREDENTIALS_PATH = os.path.join('/var/nmosauth/', 'oauth_credentials.json')
+CREDENTIALS_PATH = os.path.join('/home/dannym/', 'oauth_credentials.json')
 
 MDNS_SERVICE_TYPE = "nmos-auth"
 

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -22,14 +22,14 @@ from authlib.flask.client import OAuth
 from mdnsbridge.mdnsbridgeclient import IppmDNSBridge
 from nmoscommon.logger import Logger
 
-CREDENTIALS_PATH = os.path.join('/home/dannym', 'facade.json')  # Change this back after testing
+CREDENTIALS_PATH = os.path.join('/var/nmos-node', 'facade.json')  # Change this back after testing
 
 MDNS_SERVICE_TYPE = "nmos-auth"
 
-API_NAMESPACE = 'x-nmos/auth/v1.0/'
-REGISTRATION_ENDPOINT = urljoin(API_NAMESPACE, 'register_client')
-AUTHORIZATION_ENDPOINT = urljoin(API_NAMESPACE, 'authorize')
-TOKEN_ENDPOINT = urljoin(API_NAMESPACE, 'token')
+AUTH_APIROOT = 'x-nmos/auth/v1.0/'
+REGISTRATION_ENDPOINT = urljoin(AUTH_APIROOT, 'register_client')
+AUTHORIZATION_ENDPOINT = urljoin(AUTH_APIROOT, 'authorize')
+TOKEN_ENDPOINT = urljoin(AUTH_APIROOT, 'token')
 
 logger = Logger("auth_client", None)
 

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -49,14 +49,15 @@ def get_credentials_from_file(filename=CREDENTIALS_PATH):
 
 
 class AuthRegistrar(object):
+    """Class responsible for registering an OAuth2 client with the Auth Server"""
     def __init__(self, client_name, redirect_uri, client_uri=None,
-                 allowed_scope=None, allowed_grant="authorization_code",
+                 allowed_scope=None, allowed_grant=["authorization_code"],
                  allowed_response="code", auth_method="client_secret_basic"):
         self.client_name = client_name
         self.client_uri = client_uri
         self.redirect_uri = redirect_uri
         self.allowed_scope = allowed_scope
-        self.allowed_grant = allowed_grant
+        self.allowed_grant = "\n".join(allowed_grant)
         self.allowed_response = allowed_response
         self.auth_method = auth_method
 
@@ -126,7 +127,7 @@ class AuthRegistrar(object):
                 timeout=0.5,
                 proxies={'http': ''}
             )
-            reg_resp.raise_for_status()  # Raise error if status !=201
+            reg_resp.raise_for_status()  # Raise error if status != 201
             self._client_registry[self.client_name] = reg_resp.json()  # Keep a local record of registered clients
             return reg_resp.json()
         except HTTPError as e:
@@ -136,7 +137,9 @@ class AuthRegistrar(object):
 
 
 class AuthRegistry(OAuth):
-
+    """Subclass of top-level Authlib client.
+    Registers Auth Server URIs for requesting access tokens for each registered OAuth2 client.
+    Also responsible for storing and fetching bearer token"""
     def __init__(self):
         super(AuthRegistry, self).__init__()
         self.bridge = IppmDNSBridge()

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -168,7 +168,8 @@ class AuthRegistry(OAuth):
         self.authorize_url = urljoin(self.auth_url, AUTHORIZATION_ENDPOINT)
         self.client_kwargs = {
             "scope": "is-04",
-            'token_endpoint_auth_method': 'client_secret_basic'
+            'token_endpoint_auth_method': 'client_secret_basic',
+            'code_challenge_method': 'S256'
         }
 
     def fetch_local_token(self):

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -43,9 +43,11 @@ def get_credentials_from_file(filename=CREDENTIALS_PATH):
         client_id = credentials['client_id']
         client_secret = credentials['client_secret']
         return client_id, client_secret
-    except OSError as e:
-        logger.writeError("Could not read OAuth client credentials from file: {}. {}".format(filename, e))
+    except (OSError, IOError) as e:
+        logger.writeError("Could not read OAuth2 client credentials from file: {}. Error: {}".format(filename, e))
         raise
+    except KeyError as e:
+        logger.writeError("OAuth2 credentials not found in file: {}. Error: {}".format(filename, e))
 
 
 class AuthRegistrar(object):
@@ -108,7 +110,7 @@ class AuthRegistrar(object):
                 json.dump(data, f)
             os.chmod(file_path, 0o600)
             return True
-        except OSError as e:
+        except (OSError, IOError) as e:
             logger.writeError(
                 "Could not write OAuth client credentials to file {}. {}".format(file_path, e)
             )

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -154,8 +154,8 @@ class AuthRegistry(OAuth):
     def fetch_local_token(self):
         return self.bearer_token
 
-    # def update_local_token(self, token):
-    #     self.bearer_token = token
+    def update_local_token(self, token):
+        self.bearer_token = token
 
     def register_client(self, client_name, client_uri):
         client_id, client_secret = get_credentials_from_file(CREDENTIALS_PATH)
@@ -170,7 +170,7 @@ class AuthRegistry(OAuth):
             api_base_url=client_uri,
             client_kwargs=self.client_kwargs,
             fetch_token=self.fetch_local_token,
-            # update_token=self.update_local_token
+            update_token=self.update_local_token
         )
 
 

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -22,7 +22,7 @@ from authlib.flask.client import OAuth
 from mdnsbridge.mdnsbridgeclient import IppmDNSBridge
 from nmoscommon.logger import Logger
 
-CREDENTIALS_PATH = os.path.join('/home/dannym/', 'oauth_credentials.json')
+CREDENTIALS_PATH = os.path.join('/home/dannym/', 'oauth_credentials.json')  # Change this back after testing
 
 MDNS_SERVICE_TYPE = "nmos-auth"
 

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -46,6 +46,7 @@ from .api import NODE_APIVERSIONS # noqa E402
 from .api import NODE_REGVERSION # noqa E402
 from .aggregator import Aggregator # noqa E402
 from .aggregator import MDNSUpdater # noqa E402
+from .authclient import AuthRegistry # noqa E402
 
 from nmoscommon.utils import getLocalIP # noqa E402
 from nmoscommon.mdns import MDNSEngine # noqa E402
@@ -125,7 +126,8 @@ class NodeFacadeService:
                 self.logger,
                 txt_recs=self._mdns_txt(NODE_APIVERSIONS, protocol, OAUTH_MODE)
             )
-        self.aggregator = Aggregator(self.logger, self.mdns_updater)
+        self.auth_registry = AuthRegistry()
+        self.aggregator = Aggregator(self.logger, self.mdns_updater, self.auth_registry)
 
     def _mdns_txt(self, versions, protocol, oauth_mode):
         return {
@@ -250,7 +252,7 @@ class NodeFacadeService:
         )
         self.registry_cleaner = FacadeRegistryCleaner(self.registry)
         self.registry_cleaner.start()
-        self.httpServer = HttpServer(FacadeAPI, PORT, '0.0.0.0', api_args=[self.registry])
+        self.httpServer = HttpServer(FacadeAPI, PORT, '0.0.0.0', api_args=[self.registry, self.auth_registry])
         self.httpServer.start()
         while not self.httpServer.started.is_set():
             self.logger.writeInfo('Waiting for httpserver to start...')

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -25,7 +25,7 @@ import json
 import requests
 import traceback
 from nmosnode.aggregator import Aggregator, InvalidRequest, REGISTRATION_MDNSTYPE, AGGREGATOR_APIVERSION
-from nmosnode.aggregator import NoAggregator, AGGREGATOR_APINAMESPACE, LEGACY_REG_MDNSTYPE, AGGREGATOR_APINAME
+from nmosnode.aggregator import NoAggregator, LEGACY_REG_MDNSTYPE, AGGREGATOR_APIROOT
 from nmosnode.aggregator import TooManyRetries
 import nmosnode
 
@@ -806,7 +806,7 @@ class TestAggregator(unittest.TestCase):
                     method,
                     urljoin(
                         aggregator_url,
-                        AGGREGATOR_APINAMESPACE + "/" + AGGREGATOR_APINAME + "/" + AGGREGATOR_APIVERSION + url
+                        AGGREGATOR_APIROOT + AGGREGATOR_APIVERSION + url
                     ),
                     data=expected_data,
                     headers=headers,
@@ -816,7 +816,7 @@ class TestAggregator(unittest.TestCase):
                     method,
                     urljoin(
                         aggregator_url,
-                        AGGREGATOR_APINAMESPACE + "/" + AGGREGATOR_APINAME + "/" + AGGREGATOR_APIVERSION + url
+                        AGGREGATOR_APIROOT + AGGREGATOR_APIVERSION + url
                     ),
                     data=expected_data,
                     headers=headers,

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -45,7 +45,6 @@ class TestAggregator(unittest.TestCase):
                  'gevent.spawn']
         patchers = {name: mock.patch(name) for name in paths}
         self.mocks = {name: patcher.start() for (name, patcher) in iteritems(patchers)}
-
         self.addCleanup(mock.patch.stopall)
 
         def printmsg(t):
@@ -53,11 +52,11 @@ class TestAggregator(unittest.TestCase):
                 print(t + ": " + msg)
             return _inner
 
-#        self.mocks['nmosnode.aggregator.Logger'].return_value.writeInfo.side_effect = printmsg("INFO")
-#        self.mocks['nmosnode.aggregator.Logger'].return_value.writeWarning.side_effect = printmsg("WARNING")
-#        self.mocks['nmosnode.aggregator.Logger'].return_value.writeDebug.side_effect = printmsg("DEBUG")
-#        self.mocks['nmosnode.aggregator.Logger'].return_value.writeError.side_effect = printmsg("ERROR")
-#        self.mocks['nmosnode.aggregator.Logger'].return_value.writeFatal.side_effect = printmsg("FATAL")
+        # self.mocks['nmosnode.aggregator.Logger'].return_value.writeInfo.side_effect = printmsg("INFO")
+        # self.mocks['nmosnode.aggregator.Logger'].return_value.writeWarning.side_effect = printmsg("WARNING")
+        # self.mocks['nmosnode.aggregator.Logger'].return_value.writeDebug.side_effect = printmsg("DEBUG")
+        # self.mocks['nmosnode.aggregator.Logger'].return_value.writeError.side_effect = printmsg("ERROR")
+        # self.mocks['nmosnode.aggregator.Logger'].return_value.writeFatal.side_effect = printmsg("FATAL")
 
     def test_init(self):
         """Test a call to Aggregator()"""
@@ -766,7 +765,7 @@ class TestAggregator(unittest.TestCase):
     def assert_send_runs_correctly(
         self, method,
         url, data=None,
-        headers=None,
+        headers={},
         to_point=SEND_ITERATION_0,
         initial_aggregator="",
         aggregator_urls=[
@@ -803,8 +802,8 @@ class TestAggregator(unittest.TestCase):
         def create_mock_request(method, url, aggregator_url, expected_data, headers, prefer_ipv6=False):
             if not prefer_ipv6:
                 return (mock.call(
-                    method,
-                    urljoin(
+                    method=method,
+                    url=urljoin(
                         aggregator_url,
                         AGGREGATOR_APIROOT + AGGREGATOR_APIVERSION + url
                     ),
@@ -813,8 +812,8 @@ class TestAggregator(unittest.TestCase):
                     timeout=1.0))
             else:
                 return (mock.call(
-                    method,
-                    urljoin(
+                    method=method,
+                    url=urljoin(
                         aggregator_url,
                         AGGREGATOR_APIROOT + AGGREGATOR_APIVERSION + url
                     ),


### PR DESCRIPTION
This PR allows nmos nodes to register with an authorization server as an OAuth client, and subsequently use the authlib library to fetch tokens and add them to HTTP requests. It currently uses the client_credentials grant and the authorization code grant flows.

Further work needs to be done regarding the role of user permission in client registration (currently uses Basic Auth.)