### PR TITLE
Add OAuth 2.0 Client Registration and Token Request Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Node API Implementation Changelog
 
+## 0.12.0
+- Add OAuth 2.0 client registration and token request functionality
+
 ## 0.11.0
 - Add exponential backoff when registration APIs return HTTP 500 responses
 - Add support for un-registering when requests return HTTP 409 responses

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,47 +77,43 @@ pipeline {
                         }
                     }
                 }
-                stage ("Unit Tests") {
-                    stages {
-                        stage ("Python 2.7 Unit Tests") {
-                            steps {
-                                script {
-                                    env.py27_result = "FAILURE"
-                                }
-                                bbcGithubNotify(context: "tests/py27", status: "PENDING")
-                                // Use a workdirectory in /tmp to avoid shebang length limitation
-                                withBBCRDPythonArtifactory {
-                                    sh 'tox -e py27 --recreate --workdir /tmp/$(basename ${WORKSPACE})/tox-py27'
-                                }
-                                script {
-                                    env.py27_result = "SUCCESS" // This will only run if the sh above succeeded
-                                }
-                            }
-                            post {
-                                always {
-                                    bbcGithubNotify(context: "tests/py27", status: env.py27_result)
-                                }
-                            }
+                stage ("Python 2.7 Unit Tests") {
+                    steps {
+                        script {
+                            env.py27_result = "FAILURE"
                         }
-                        stage ("Python 3 Unit Tests") {
-                            steps {
-                                script {
-                                    env.py3_result = "FAILURE"
-                                }
-                                bbcGithubNotify(context: "tests/py3", status: "PENDING")
-                                // Use a workdirectory in /tmp to avoid shebang length limitation
-                                withBBCRDPythonArtifactory {
-                                  sh 'tox -e py3 --recreate --workdir /tmp/$(basename ${WORKSPACE})/tox-py3'
-                                }
-                                script {
-                                    env.py3_result = "SUCCESS" // This will only run if the sh above succeeded
-                                }
-                            }
-                            post {
-                                always {
-                                    bbcGithubNotify(context: "tests/py3", status: env.py3_result)
-                                }
-                            }
+                        bbcGithubNotify(context: "tests/py27", status: "PENDING")
+                        // Use a workdirectory in /tmp to avoid shebang length limitation
+                        withBBCRDPythonArtifactory {
+                            sh 'tox -e py27 --recreate --workdir /tmp/$(basename ${WORKSPACE})/tox-py27'
+                        }
+                        script {
+                            env.py27_result = "SUCCESS" // This will only run if the sh above succeeded
+                        }
+                    }
+                    post {
+                        always {
+                            bbcGithubNotify(context: "tests/py27", status: env.py27_result)
+                        }
+                    }
+                }
+                stage ("Python 3 Unit Tests") {
+                    steps {
+                        script {
+                            env.py3_result = "FAILURE"
+                        }
+                        bbcGithubNotify(context: "tests/py3", status: "PENDING")
+                        // Use a workdirectory in /tmp to avoid shebang length limitation
+                        withBBCRDPythonArtifactory {
+                          sh 'tox -e py3 --recreate --workdir /tmp/$(basename ${WORKSPACE})/tox-py3'
+                        }
+                        script {
+                            env.py3_result = "SUCCESS" // This will only run if the sh above succeeded
+                        }
+                    }
+                    post {
+                        always {
+                            bbcGithubNotify(context: "tests/py3", status: env.py3_result)
                         }
                     }
                 }

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -92,10 +92,6 @@ class Aggregator(object):
                 }
             }
         }
-        self._reg_queue = gevent.queue.Queue()
-        self.main_thread = gevent.spawn(self._main_thread)
-        self.queue_thread = gevent.spawn(self._process_queue)
-
         self._running = True
         self._aggregator_list_stale = True
         self._aggregator_failure = False  # Variable to flag when aggregator has returned and unexpected error
@@ -105,6 +101,10 @@ class Aggregator(object):
         self.auth_registrar = None  # Class responsible for registering with Auth Server
         self.auth_registry = auth_registry  # Top level class that tracks locally registered OAuth clients
         self.auth_client = None  # Instance of Oauth client responsible for performing token requests
+
+        self._reg_queue = gevent.queue.Queue()
+        self.main_thread = gevent.spawn(self._main_thread)
+        self.queue_thread = gevent.spawn(self._process_queue)
 
     def _set_api_version_and_srv_type(self, api_ver):
         """Set the aggregator api version equal to parameter and DNS-SD service type based on api version"""

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -225,9 +225,10 @@ class Aggregator(object):
     def _register_auth(self, client_name, client_uri):
         """Register OAuth client with Authorization Server"""
         self.logger.writeInfo("Attempting to register dynamically with Auth Server")
+        protocol = "https" if _config.get('https_mode') == "enabled" else "http"
         auth_registrar = AuthRegistrar(
             client_name=client_name,
-            redirect_uri='http://' + HOSTNAME + NODE_APIROOT + 'authorize',
+            redirect_uri=protocol + '://' + HOSTNAME + NODE_APIROOT + 'authorize',
             client_uri=client_uri,
             allowed_scope=ALLOWED_SCOPE,
             allowed_grant=ALLOWED_GRANTS

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -522,7 +522,7 @@ class Aggregator(object):
                     # Store token in member variable to be extracted using `fetch_local_token` function
                     self.auth_registry.bearer_token = token
                 else:
-                    raise OAuth2Error("Client registered with unsupported Grant Type")
+                    raise OAuth2Error("Client not registered with supported Grant Type")
             except OAuth2Error as e:
                 self.logger.writeError("Failure fetching access token. {}".format(e))
 
@@ -662,7 +662,8 @@ class Aggregator(object):
                 # General OAuth Error (e.g. incorrect request details, invalid client, etc.)
                 except OAuth2Error as e:
                     self.logger.writeError(
-                        "Failed to fetch token before making API call to {}. Error: {}".format(url, e))
+                        "Failed to fetch token before making API call to {}. {}".format(url, e))
+                    self.auth_registrar = None
 
 
 class MDNSUpdater(object):

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -499,6 +499,7 @@ class Aggregator(object):
                     # Register Node Client
                     self.auth_registry.register_client(
                         client_name=client_name, client_uri=client_uri, **self.auth_registrar.server_metadata)
+                    self.logger.writeInfo("Successfully registered Auth Client")
                 except (OSError, IOError):
                     self.logger.writeError(
                         "Exception accessing OAuth credentials. This may be a file permissions issue.")
@@ -513,8 +514,8 @@ class Aggregator(object):
         if self.auth_client is not None and self.auth_registrar is not None:
             try:
                 if "authorization_code" in self.auth_registrar.allowed_grant:
-                    # Open browser at endpoint for redirecting to Auth Server's /authorize endpoint
-                    webbrowser.open("http://" + HOSTNAME + NODE_APIROOT + "login")
+                    # Endpoint '/login' on Node will provide redirect to authorization endpoint on Auth Server
+                    return
                 elif "client_credentials" in self.auth_registrar.allowed_grant:
                     # Fetch Token
                     token = self.auth_client.fetch_access_token()

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -104,6 +104,9 @@ class Aggregator(object):
         self.auth_registrar = None  # Class responsible for registering with Auth Server
         self.auth_registry = auth_registry  # Top level class that tracks locally registered OAuth clients
         self.auth_client = None  # Instance of Oauth client responsible for performing token requests
+        # Something like...
+        if OAUTH_MODE is True:
+            self.register_auth_client("Node on {}".format(getfqdn(), getfqdn()))
 
     def _set_api_version_and_srv_type(self, api_ver):
         """Set the aggregator api version equal to parameter and DNS-SD service type based on api version"""

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -12,26 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gevent
 from gevent import monkey
 monkey.patch_all()
 
-from six import itervalues # noqa E402
-from six.moves.urllib.parse import urljoin, urlparse # noqa E402
-
-from collections import deque # noqa E402
+import gevent # noqa E402
+import gevent.queue # noqa E402
 import requests # noqa E402
+import traceback # noqa E402
 import json # noqa E402
 import time # noqa E402
 
-import gevent.queue # noqa E402
-
-from nmoscommon.logger import Logger # noqa E402
-from mdnsbridge.mdnsbridgeclient import IppmDNSBridge, NoService, EndOfServiceList # noqa E402
-from nmoscommon.mdns.mdnsExceptions import ServiceNotFoundException # noqa E402
+from six import itervalues # noqa E402
+from six.moves.urllib.parse import urljoin, urlparse # noqa E402
+from collections import deque # noqa E402
 
 from nmoscommon.nmoscommonconfig import config as _config # noqa E402
-import traceback # noqa E402
+from nmoscommon.logger import Logger # noqa E402
+from nmoscommon.mdns.mdnsExceptions import ServiceNotFoundException # noqa E402
+from mdnsbridge.mdnsbridgeclient import IppmDNSBridge, NoService, EndOfServiceList # noqa E402
 
 AGGREGATOR_APINAMESPACE = "x-nmos"
 AGGREGATOR_APINAME = "registration"
@@ -326,14 +324,14 @@ class Aggregator(object):
             return self.mdnsbridge.getHrefWithException(self.service_type, None, self.aggregator_apiversion, protocol)
         except NoService:
             self.logger.writeDebug("No Registration services found: {} {} {}".format(
-                                    self.service_type, self.aggregator_apiversion, protocol))
+                self.service_type, self.aggregator_apiversion, protocol))
             if self._mdns_updater is not None:
                 self._mdns_updater.inc_P2P_enable_count()
             self._increase_backoff_period()
             return None
         except EndOfServiceList:
             self.logger.writeDebug("End of Registration services list: {} {} {}".format(
-                                    self.service_type, self.aggregator_apiversion, protocol))
+                self.service_type, self.aggregator_apiversion, protocol))
             self._increase_backoff_period()
             return None
 
@@ -369,10 +367,10 @@ class Aggregator(object):
         self.logger.writeDebug("Starting HTTP queue processing thread")
         # Checks queue not empty before quitting to make sure unregister node gets done
         while self._running:
-            if (not self._node_data["registered"] or
-                    self._reg_queue.empty() or
-                    self._backoff_active or
-                    not self.aggregator):
+            if (not self._node_data["registered"]
+                    or self._reg_queue.empty()
+                    or self._backoff_active
+                    or not self.aggregator):
                 gevent.sleep(1)
             else:
                 try:
@@ -618,7 +616,7 @@ class MDNSUpdater(object):
                 self._mdns_update_queue.put(self._p2p_txt_recs())
 
     def _increment_service_version(self, type):
-        self.service_versions[self.mappings[type]] = self.service_versions[self.mappings[type]]+1
+        self.service_versions[self.mappings[type]] = self.service_versions[self.mappings[type]] + 1
         if self.service_versions[self.mappings[type]] > 255:
             self.service_versions[self.mappings[type]] = 0
 

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -513,10 +513,11 @@ class Aggregator(object):
         """Fetch Access Token either using redirection grant flow or using auth_client"""
         if self.auth_client is not None and self.auth_registrar is not None:
             try:
-                if "authorization_code" in self.auth_registrar.allowed_grant:
-                    # Endpoint '/login' on Node will provide redirect to authorization endpoint on Auth Server
+                if "authorization_code" in self.auth_registrar.client_metadata.get("grant_types", {}):
+                    self.logger.writeInfo(
+                        "Endpoint '/login' on Node API will provide redirect to authorization endpoint on Auth Server.")
                     return
-                elif "client_credentials" in self.auth_registrar.allowed_grant:
+                elif "client_credentials" in self.auth_registrar.client_metadata.get("grant_types", {}):
                     # Fetch Token
                     token = self.auth_client.fetch_access_token()
                     # Store token in member variable to be extracted using `fetch_local_token` function
@@ -657,7 +658,7 @@ class Aggregator(object):
                     try:
                         return self.auth_client.request(**kwargs)  # Resend the request
                     except Exception as e:
-                        self.logger.writeError("Error re-requesting token: {}. Removing Auth Client".format(e))
+                        self.logger.writeError("Error re-requesting token: {}.".format(e))
                         self.auth_client = None
                 # General OAuth Error (e.g. incorrect request details, invalid client, etc.)
                 except OAuth2Error as e:

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -596,22 +596,22 @@ class Aggregator(object):
         url = "{}/{}/{}".format(AGGREGATOR_APIROOT, api_ver, url)
 
         try:
-            R = self._send_request(method, aggregator, url, data)
-            if R is None:
+            resp = self._send_request(method, aggregator, url, data)
+            if resp is None:
                 self.logger.writeWarning("No response from aggregator {}".format(aggregator))
                 raise ServerSideError
 
-            elif R.status_code in [200, 201, 204, 409]:
-                return R
+            elif resp.status_code in [200, 201, 204, 409]:
+                return resp
 
-            elif (R.status_code // 100) == 4:
+            elif (resp.status_code // 100) == 4:
                 self.logger.writeWarning("{} response from aggregator: {} {}"
-                                         .format(R.status_code, method, urljoin(aggregator, url)))
-                raise InvalidRequest(R.status_code)
+                                         .format(resp.status_code, method, urljoin(aggregator, url)))
+                raise InvalidRequest(resp.status_code)
 
             else:
                 self.logger.writeWarning("Unexpected status from aggregator {}: {}, {}"
-                                         .format(aggregator, R.status_code, R.content))
+                                         .format(aggregator, resp.status_code, resp.content))
                 raise ServerSideError
 
         except requests.exceptions.RequestException as e:

--- a/nmosnode/aggregator.py
+++ b/nmosnode/aggregator.py
@@ -607,6 +607,7 @@ class Aggregator(object):
             elif (resp.status_code // 100) == 4:
                 self.logger.writeWarning("{} response from aggregator: {} {}"
                                          .format(resp.status_code, method, urljoin(aggregator, url)))
+                self.logger.writeDebug("\nResponse: {}".format(resp.content))
                 raise InvalidRequest(resp.status_code)
 
             else:
@@ -631,7 +632,7 @@ class Aggregator(object):
         # to web clients - so, sacrifice a little timeliness for things working as designed the
         # majority of the time...
         kwargs = {
-            "method": method, "url": url, "data": data, "timeout": 1.0
+            "method": method, "url": url, "json": data, "timeout": 1.0
         }
         if _config.get('prefer_ipv6') is True:
             kwargs["proxies"] = {'http': ''}

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -76,7 +76,7 @@ class FacadeAPI(WebAPI):
         """Authorize Auth Server redirect to obtain token then store in memory"""
         self.auth_client = getattr(self.auth_registry, self.auth_registry.client_name)
         token = self.auth_client.authorize_access_token()
-        self.auth_registry.bearer_token = token
+        self.auth_registry.update_local_token(token)
         return redirect(url_for('_nameroot'))
 
     @route(NODE_APIROOT + "<api_version>/")

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -65,8 +65,11 @@ class FacadeAPI(WebAPI):
     def oauth(self):
         """Redirect to Auth Server's authorization endpoint"""
         redirect_uri = url_for('_authorization', _external=True)
-        self.auth_client = getattr(self.auth_registry, self.auth_registry.client_name)
-        return self.auth_client.authorize_redirect(redirect_uri)
+        if self.auth_registry.client_name:
+            self.auth_client = getattr(self.auth_registry, self.auth_registry.client_name)
+            return self.auth_client.authorize_redirect(redirect_uri)
+        else:
+            abort(400, "Client not registered with Auth Server")
 
     @route(NODE_APIROOT + "authorize", auto_json=False)
     def authorization(self):

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -61,7 +61,7 @@ class FacadeAPI(WebAPI):
     def nameroot(self):
         return [api_version + "/" for api_version in NODE_APIVERSIONS]
 
-    @route(NODE_APIROOT + "login", auto_json=False)
+    @route(NODE_APIROOT + "login/", auto_json=False)
     def login(self):
         """Redirect to Auth Server's authorization endpoint"""
         redirect_uri = url_for('_authorization', _external=True)
@@ -71,6 +71,7 @@ class FacadeAPI(WebAPI):
     @route(NODE_APIROOT + "authorize", auto_json=False)
     def authorization(self):
         """Authorize Auth Server redirect to obtain token then store in memory"""
+        self.auth_client = getattr(self.auth_registry, self.auth_registry.client_name)
         token = self.auth_client.authorize_access_token()
         self.auth_registry.bearer_token = token
         return redirect(url_for('_nameroot'))

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -61,8 +61,8 @@ class FacadeAPI(WebAPI):
     def nameroot(self):
         return [api_version + "/" for api_version in NODE_APIVERSIONS]
 
-    @route(NODE_APIROOT + "login/", auto_json=False)
-    def login(self):
+    @route(NODE_APIROOT + "oauth/", auto_json=False)
+    def oauth(self):
         """Redirect to Auth Server's authorization endpoint"""
         redirect_uri = url_for('_authorization', _external=True)
         self.auth_client = getattr(self.auth_registry, self.auth_registry.client_name)

--- a/nmosnode/api.py
+++ b/nmosnode/api.py
@@ -28,7 +28,9 @@ from nmoscommon.webapi import WebAPI, route, resource_route, abort
 NODE_APIVERSIONS = ["v1.0", "v1.1", "v1.2", "v1.3"]
 if _config.get("https_mode", "disabled") == "enabled":
     NODE_APIVERSIONS.remove("v1.0")
+
 NODE_REGVERSION = _config.get('nodefacade', {}).get('NODE_REGVERSION', 'v1.2')
+
 NODE_APINAMESPACE = "x-nmos"
 NODE_APINAME = "node"
 NODE_APIROOT = '/' + NODE_APINAMESPACE + '/' + NODE_APINAME + '/'

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -141,7 +141,6 @@ class AuthRegistrar(object):
             url = urljoin(auth_href, SERVER_METADATA_ENDPOINT)
             resp = requests.get(url, timeout=0.5, proxies={'http': ''})
             resp.raise_for_status()  # Raise exception if not a 2XX status code
-            print(resp.json())
             return resp.json()
         except Exception as e:
             logger.writeWarning("Unable to retrieve server metadata - falling back to defaults. {}".format(e))
@@ -166,7 +165,6 @@ class AuthRegistrar(object):
             reg_resp = requests.post(
                 oauth_registration_href,
                 data=data,
-                auth=('dannym', 'password'),
                 timeout=0.5,
                 proxies={'http': ''}
             )

--- a/nmosnode/authclient.py
+++ b/nmosnode/authclient.py
@@ -1,0 +1,215 @@
+# Copyright 2019 British Broadcasting Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import json
+import requests
+from requests.exceptions import HTTPError
+from six.moves.urllib.parse import urljoin
+from authlib.flask.client import OAuth
+
+from mdnsbridge.mdnsbridgeclient import IppmDNSBridge
+from nmoscommon.logger import Logger
+
+CREDENTIALS_PATH = os.path.join('/var/nmos-node', 'facade.json')  # Change this back after testing
+
+MDNS_SERVICE_TYPE = "nmos-auth"
+
+AUTH_APIROOT = 'x-nmos/auth/v1.0/'
+REGISTRATION_ENDPOINT = urljoin(AUTH_APIROOT, 'register_client')
+AUTHORIZATION_ENDPOINT = urljoin(AUTH_APIROOT, 'authorize')
+TOKEN_ENDPOINT = urljoin(AUTH_APIROOT, 'token')
+
+logger = Logger("auth_client", None)
+
+
+def get_credentials_from_file(filename):
+    try:
+        with open(filename, 'r') as f:
+            credentials = json.load(f)
+        client_id = credentials['client_id']
+        client_secret = credentials['client_secret']
+        return client_id, client_secret
+    except (OSError, IOError) as e:
+        logger.writeError("Could not read OAuth2 client credentials from file: {}. Error: {}".format(filename, e))
+        raise
+    except KeyError as e:
+        logger.writeError("OAuth2 credentials not found in file: {}. Error: {}".format(filename, e))
+        raise
+
+
+class AuthRegistrar(object):
+    """Class responsible for registering an OAuth2 client with the Auth Server"""
+    def __init__(self, client_name, redirect_uri, client_uri=None,
+                 allowed_scope=None, allowed_grant=["authorization_code"],
+                 allowed_response="code", auth_method="client_secret_basic"):
+        self.client_name = client_name
+        self.client_uri = client_uri
+        self.redirect_uri = redirect_uri
+        self.allowed_scope = allowed_scope
+        self.allowed_grant = "\n".join(allowed_grant)
+        self.allowed_response = allowed_response
+        self.auth_method = auth_method
+
+        self.client_id = None
+        self.client_secret = None
+        self.bridge = IppmDNSBridge()
+        self._client_registry = {}
+        self.registered = False  # Flag to signify Node is registered with Auth Server
+        self.initialised = self.initialise(CREDENTIALS_PATH)
+
+    def initialise(self, credentials_path):
+        """Check if credentials file already exists, meaning the device is already registered.
+        If not, register with Auth Server and write client credentials to file."""
+        try:
+            if os.path.isfile(credentials_path):
+                with open(credentials_path, 'r') as f:
+                    data = json.load(f)
+                if "client_id" in data and "client_secret" in data:
+                    logger.writeWarning("Credentials file already exists. Using existing credentials.")
+                    self.client_id, self.client_secret = get_credentials_from_file(credentials_path)
+                    self.registered = True
+                    return True
+            logger.writeInfo("Registering with Authorization Server...")
+            if self.registered is False:
+                reg_resp_json = self.send_oauth_registration_request()
+                self.registered = True
+            logger.writeInfo("Writing OAuth2 credentials to file...")
+            self.write_credentials_to_file(reg_resp_json, credentials_path)
+            return True
+        except Exception as e:
+            logger.writeError(
+                "Unable to initialise OAuth Client with client credentials. {}".format(e)
+            )
+            return False
+
+    def write_credentials_to_file(self, data, file_path):
+        try:
+            self.client_id = data.get('client_id')
+            self.client_secret = data.get('client_secret')
+            credentials = {
+                "client_id": self.client_id,
+                "client_secret": self.client_secret
+            }
+            # Load contents if file exists
+            if os.path.exists(file_path):
+                with open(file_path) as f:
+                    data = json.load(f)
+                data.update(credentials)
+            else:
+                data = credentials
+            # Write credentials to file
+            with open(file_path, 'w') as f:
+                json.dump(data, f)
+            return True
+        except (OSError, IOError) as e:
+            logger.writeError(
+                "Could not write OAuth client credentials to file {}. {}".format(file_path, e)
+            )
+            raise
+
+    def send_oauth_registration_request(self):
+        try:
+            href = self.bridge.getHref(MDNS_SERVICE_TYPE)
+            registration_href = urljoin(href, REGISTRATION_ENDPOINT)
+            logger.writeDebug('Registration endpoint href is: {}'.format(registration_href))
+
+            data = {
+                "client_name": self.client_name,
+                "client_uri": self.client_uri,
+                "scope": self.allowed_scope,
+                "redirect_uri": self.redirect_uri,
+                "grant_type": self.allowed_grant,
+                "response_type": self.allowed_response,
+                "token_endpoint_auth_method": self.auth_method
+            }
+
+            # Decide how Basic Auth details are retrieved - user input? Retrieved from file?
+            reg_resp = requests.post(
+                registration_href,
+                data=data,
+                auth=('dannym', 'password'),
+                timeout=0.5,
+                proxies={'http': ''}
+            )
+            reg_resp.raise_for_status()  # Raise error if status is an error code
+            self._client_registry[self.client_name] = reg_resp.json()  # Keep a local record of registered clients
+            return reg_resp.json()
+        except HTTPError as e:
+            logger.writeError("Unable to Register Client with Auth Server. {}".format(e))
+            logger.writeDebug(e.response.text)
+            raise
+
+
+class AuthRegistry(OAuth):
+    """Subclass of top-level Authlib client.
+    Registers Auth Server URIs for requesting access tokens for each registered OAuth2 client.
+    Also responsible for storing and fetching bearer token"""
+    def __init__(self):
+        super(AuthRegistry, self).__init__()
+        self.bridge = IppmDNSBridge()
+        self.client_name = None
+        self.client_uri = None
+        self.bearer_token = None
+        self.auth_url = self.bridge.getHref(MDNS_SERVICE_TYPE)
+        self.token_url = urljoin(self.auth_url, TOKEN_ENDPOINT)
+        self.refresh_url = urljoin(self.auth_url, TOKEN_ENDPOINT)
+        self.authorize_url = urljoin(self.auth_url, AUTHORIZATION_ENDPOINT)
+        self.client_kwargs = {
+            "scope": "is-04",
+            'token_endpoint_auth_method': 'client_secret_basic',
+            'code_challenge_method': 'S256'
+        }
+
+    def fetch_local_token(self):
+        return self.bearer_token
+
+    def update_local_token(self, token):
+        self.bearer_token = token
+
+    def register_client(self, client_name, client_uri, credentials_path=CREDENTIALS_PATH):
+        client_id, client_secret = get_credentials_from_file(credentials_path)
+        self.client_name = client_name
+        self.client_uri = client_uri
+        return self.register(
+            name=client_name,
+            client_id=client_id,
+            client_secret=client_secret,
+            access_token_url=self.token_url,
+            refresh_token_url=self.refresh_url,
+            authorize_url=self.authorize_url,
+            api_base_url=client_uri,
+            client_kwargs=self.client_kwargs,
+            fetch_token=self.fetch_local_token,
+            update_token=self.update_local_token
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+
+    client_name = "test_oauth_client"
+    client_uri = "www.example.com"
+
+    auth_reg = AuthRegistrar(
+        client_name=client_name,
+        client_uri=client_uri,
+        allowed_scope="is-04",
+        redirect_uri="www.app.example.com",
+        allowed_grant="password\nauthorization_code",  # Authlib only accepts grants seperated with newline chars
+        allowed_response="code",
+        auth_method="client_secret_basic"
+    )
+    if auth_reg.initialised is True:
+        auth_client = AuthRegistry(name=client_name, uri=client_uri)
+        print(auth_client.fetch_token())

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -43,15 +43,11 @@ from nmoscommon.httpserver import HttpServer # noqa E402
 from nmoscommon.utils import get_node_id, translate_api_version, getLocalIP # noqa E402
 from nmoscommon.nmoscommonconfig import config as _config # noqa E402
 
-from .api import NODE_APIVERSIONS # noqa E402
-from .api import NODE_REGVERSION # noqa E402
-from .api import FacadeAPI # noqa E402
+from .api import NODE_APIVERSIONS, NODE_REGVERSION, FacadeAPI # noqa E402
 from .registry import FacadeRegistry, FacadeRegistryCleaner # noqa E402
-from .aggregator import Aggregator # noqa E402
-from .aggregator import MDNSUpdater # noqa E402
+from .aggregator import Aggregator, MDNSUpdater # noqa E402
 from .authclient import AuthRegistry # noqa E402
 from .serviceinterface import FacadeInterface # noqa E402
-
 
 NS = 'urn:x-bbcrd:ips:ns:0.1'
 PORT = 12345

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -108,7 +108,6 @@ class NodeFacadeService:
         }
         self.mdns_updater = None
         self.auth_registry = AuthRegistry()
-        self.aggregator = Aggregator(self.logger, self.mdns_updater, self.auth_registry)
 
         if ENABLE_P2P:
             if HTTPS_MODE == "enabled":
@@ -121,6 +120,8 @@ class NodeFacadeService:
                 self.mdns, DNS_SD_TYPE, DNS_SD_NAME, self.mappings, self.dns_sd_port, self.logger,
                 txt_recs=self._mdns_txt(NODE_APIVERSIONS, self.protocol, OAUTH_MODE)
             )
+
+        self.aggregator = Aggregator(self.logger, self.mdns_updater, self.auth_registry)
 
     def _mdns_txt(self, versions, protocol, oauth_mode):
         return {

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -16,7 +16,7 @@ from __future__ import print_function, absolute_import
 from gevent import monkey
 monkey.patch_all()
 
-import gevent
+import gevent # noqa E402
 import time # noqa E402
 import signal # noqa E402
 import os  # noqa E402

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -235,7 +235,8 @@ class NodeFacadeService:
         )
         self.registry_cleaner = FacadeRegistryCleaner(self.registry)
         self.registry_cleaner.start()
-        self.httpServer = HttpServer(FacadeAPI, PORT, '0.0.0.0', api_args=[self.registry, self.auth_registry])
+        self.httpServer = HttpServer(
+            FacadeAPI, PORT, '0.0.0.0', api_args=[self.registry, self.auth_registry])
         self.httpServer.start()
         while not self.httpServer.started.is_set():
             self.logger.writeInfo('Waiting for httpserver to start...')

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -109,13 +109,13 @@ class NodeFacadeService:
         self.mdns_updater = None
         self.auth_registry = AuthRegistry()
 
+        if HTTPS_MODE == "enabled":
+            self.dns_sd_port = DNS_SD_HTTPS_PORT
+            self.protocol = "https"
+        else:
+            self.dns_sd_port = DNS_SD_HTTP_PORT
+            self.protocol = "http"
         if ENABLE_P2P:
-            if HTTPS_MODE == "enabled":
-                self.dns_sd_port = DNS_SD_HTTPS_PORT
-                self.protocol = "https"
-            else:
-                self.dns_sd_port = DNS_SD_HTTP_PORT
-                self.protocol = "http"
             self.mdns_updater = MDNSUpdater(
                 self.mdns, DNS_SD_TYPE, DNS_SD_NAME, self.mappings, self.dns_sd_port, self.logger,
                 txt_recs=self._mdns_txt(NODE_APIVERSIONS, self.protocol, OAUTH_MODE)

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -13,46 +13,45 @@
 # limitations under the License.
 
 from __future__ import print_function, absolute_import
-
-import gevent
 from gevent import monkey
 monkey.patch_all()
 
+import gevent
 import time # noqa E402
 import signal # noqa E402
 import os  # noqa E402
 import sys # noqa E402
 import json # noqa E402
-from six import itervalues # noqa E402
+import socket # noqa E402
 
-from nmoscommon.httpserver import HttpServer # noqa E402
-from nmoscommon.utils import get_node_id, translate_api_version # noqa E402
+from six import itervalues # noqa E402
 from socket import gethostname, getfqdn # noqa E402
-from .api import FacadeAPI # noqa E402
-from .registry import FacadeRegistry, FacadeRegistryCleaner # noqa E402
-from .serviceinterface import FacadeInterface # noqa E402
 from os import getpid # noqa E402
 from subprocess import check_output # noqa E402
 # Handle if systemd is installed instead of newer cysystemd
-# noqa E402
 try:
-    from cysystemd import daemon
+    from cysystemd import daemon # noqa E402
     SYSTEMD_READY = daemon.Notification.READY
 except ImportError:
-    from systemd import daemon
+    from systemd import daemon # noqa E402
     SYSTEMD_READY = "READY=1"
 
-from .api import NODE_APIVERSIONS # noqa E402
-from .api import NODE_REGVERSION # noqa E402
-from .aggregator import Aggregator # noqa E402
-from .aggregator import MDNSUpdater # noqa E402
-
-from nmoscommon.utils import getLocalIP # noqa E402
 from nmoscommon.mdns import MDNSEngine # noqa E402
 from nmoscommon.logger import Logger # noqa E402
 from nmoscommon import ptptime # noqa E402
+from nmoscommon.httpserver import HttpServer # noqa E402
+from nmoscommon.utils import get_node_id, translate_api_version, getLocalIP # noqa E402
 from nmoscommon.nmoscommonconfig import config as _config # noqa E402
-import socket # noqa E402
+
+from .api import NODE_APIVERSIONS # noqa E402
+from .api import NODE_REGVERSION # noqa E402
+from .api import FacadeAPI # noqa E402
+from .registry import FacadeRegistry, FacadeRegistryCleaner # noqa E402
+from .aggregator import Aggregator # noqa E402
+from .aggregator import MDNSUpdater # noqa E402
+from .authclient import AuthRegistry # noqa E402
+from .serviceinterface import FacadeInterface # noqa E402
+
 
 NS = 'urn:x-bbcrd:ips:ns:0.1'
 PORT = 12345
@@ -109,27 +108,25 @@ class NodeFacadeService:
             "self": "ver_slf"
         }
         self.mdns_updater = None
-        if HTTPS_MODE == "enabled" and ENABLE_P2P:
+        self.auth_registry = AuthRegistry()
+        self.aggregator = Aggregator(self.logger, self.mdns_updater, self.auth_registry)
+
+        if ENABLE_P2P:
+            if HTTPS_MODE == "enabled":
+                self.dns_sd_port = DNS_SD_HTTPS_PORT
+                self.protocol = "https"
+            else:
+                self.dns_sd_port = DNS_SD_HTTP_PORT
+                self.protocol = "http"
             self.mdns_updater = MDNSUpdater(
                 self.mdns,
                 DNS_SD_TYPE,
                 DNS_SD_NAME,
                 self.mappings,
-                DNS_SD_HTTPS_PORT,
+                self.dns_sd_port,
                 self.logger,
-                txt_recs=self._mdns_txt(NODE_APIVERSIONS, "https", OAUTH_MODE)
+                txt_recs=self._mdns_txt(NODE_APIVERSIONS, self.protocol, OAUTH_MODE)
             )
-        elif ENABLE_P2P:
-            self.mdns_updater = MDNSUpdater(
-                self.mdns,
-                DNS_SD_TYPE,
-                DNS_SD_NAME,
-                self.mappings,
-                DNS_SD_HTTP_PORT,
-                self.logger,
-                txt_recs=self._mdns_txt(NODE_APIVERSIONS, "http", OAUTH_MODE)
-            )
-        self.aggregator = Aggregator(self.logger, self.mdns_updater)
 
     def _mdns_txt(self, versions, protocol, oauth_mode):
         return {
@@ -146,27 +143,20 @@ class NodeFacadeService:
         if getLocalIP() != "":
             global HOST
             HOST = updateHost()
-            self.registry.modify_node(href=self.generate_href(),
-                                      host=HOST,
-                                      api={"versions": NODE_APIVERSIONS, "endpoints": self.generate_endpoints()},
-                                      interfaces=self.list_interfaces())
+            self.registry.modify_node(
+                href=self.generate_href(),
+                host=HOST,
+                api={"versions": NODE_APIVERSIONS, "endpoints": self.generate_endpoints()},
+                interfaces=self.list_interfaces()
+            )
 
     def generate_endpoints(self):
-        endpoints = []
-        if HTTPS_MODE != "enabled":
-            endpoints.append({
-                "host": HOST,
-                "port": DNS_SD_HTTP_PORT,  # Everything should go via apache proxy
-                "protocol": "http",
-                "authorization": OAUTH_MODE
-            })
-        if HTTPS_MODE != "disabled":
-            endpoints.append({
-                "host": HOST,
-                "port": DNS_SD_HTTPS_PORT,  # Everything should go via apache proxy
-                "protocol": "https",
-                "authorization": OAUTH_MODE
-            })
+        endpoints = {
+            "host": HOST,
+            "port": self.dns_sd_port,  # Everything should go via apache proxy
+            "protocol": self.protocol,
+            "authorization": OAUTH_MODE
+        }
         return endpoints
 
     def generate_href(self):
@@ -243,15 +233,17 @@ class NodeFacadeService:
             "clocks": [],
             "interfaces": self.list_interfaces()
         }
-        self.registry = FacadeRegistry(self.mappings.keys(),
-                                       self.aggregator,
-                                       self.mdns_updater,
-                                       self.node_id,
-                                       node_data,
-                                       self.logger)
+        self.registry = FacadeRegistry(
+            self.mappings.keys(),
+            self.aggregator,
+            self.mdns_updater,
+            self.node_id,
+            node_data,
+            self.logger
+        )
         self.registry_cleaner = FacadeRegistryCleaner(self.registry)
         self.registry_cleaner.start()
-        self.httpServer = HttpServer(FacadeAPI, PORT, '0.0.0.0', api_args=[self.registry])
+        self.httpServer = HttpServer(FacadeAPI, PORT, '0.0.0.0', api_args=[self.registry, self.auth_registry])
         self.httpServer.start()
         while not self.httpServer.started.is_set():
             self.logger.writeInfo('Waiting for httpserver to start...')

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -26,7 +26,7 @@ import socket # noqa E402
 
 from six import itervalues # noqa E402
 from socket import gethostname, getfqdn # noqa E402
-from os import getpid # noqa E402
+from os import getpid, environ # noqa E402
 from subprocess import check_output # noqa E402
 # Handle if systemd is installed instead of newer cysystemd
 try:
@@ -61,6 +61,9 @@ FQDN = getfqdn()
 HTTPS_MODE = _config.get('https_mode', 'disabled')
 ENABLE_P2P = _config.get('node_p2p_enable', True)
 OAUTH_MODE = _config.get('oauth_mode', False)
+
+# BYPASS AUTHLIB SECURITY CHECK DUE TO REVERSE PROXY
+environ["AUTHLIB_INSECURE_TRANSPORT"] = "1"
 
 
 def updateHost():

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -119,12 +119,7 @@ class NodeFacadeService:
                 self.dns_sd_port = DNS_SD_HTTP_PORT
                 self.protocol = "http"
             self.mdns_updater = MDNSUpdater(
-                self.mdns,
-                DNS_SD_TYPE,
-                DNS_SD_NAME,
-                self.mappings,
-                self.dns_sd_port,
-                self.logger,
+                self.mdns, DNS_SD_TYPE, DNS_SD_NAME, self.mappings, self.dns_sd_port, self.logger,
                 txt_recs=self._mdns_txt(NODE_APIVERSIONS, self.protocol, OAUTH_MODE)
             )
 
@@ -151,12 +146,13 @@ class NodeFacadeService:
             )
 
     def generate_endpoints(self):
-        endpoints = {
+        endpoints = []
+        endpoints.append({
             "host": HOST,
             "port": self.dns_sd_port,  # Everything should go via apache proxy
             "protocol": self.protocol,
             "authorization": OAUTH_MODE
-        }
+        })
         return endpoints
 
     def generate_href(self):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 
 # Basic metadata
 name = "nodefacade"
-version = "0.11.0"
+version = "0.12.0"
 description = "BBC implementation of an AMWA NMOS Node API"
 url = "https://github.com/bbc/nmos-node"
 author = "Peter Brightwell"

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1334,7 +1334,7 @@ class TestAggregator(unittest.TestCase):
                     method=method,
                     url=urljoin(
                         aggregator_url,
-                        AGGREGATOR_APINAMESPACE + "/" + AGGREGATOR_APINAME + "/" + a.aggregator_apiversion + url
+                        AGGREGATOR_APINAMESPACE + "/" + AGGREGATOR_APINAME + "/" + a.aggregator_apiversion + '/' + url
                     ),
                     json=expected_data,
                     timeout=1.0))
@@ -1343,7 +1343,7 @@ class TestAggregator(unittest.TestCase):
                     method=method,
                     url=urljoin(
                         aggregator_url,
-                        AGGREGATOR_APINAMESPACE + "/" + AGGREGATOR_APINAME + "/" + a.aggregator_apiversion + url
+                        AGGREGATOR_APINAMESPACE + "/" + AGGREGATOR_APINAME + "/" + a.aggregator_apiversion + '/' + url
                     ),
                     json=expected_data,
                     timeout=1.0,

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1377,7 +1377,7 @@ class TestAggregator(unittest.TestCase):
 
         def request(*args, **kwargs):
             return mock.MagicMock(status_code=200, content=TEST_CONTENT)
-        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "/test",
+        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "test",
                                         request=request, expected_return=TEST_CONTENT)
 
     def test_send_200_response_ipv6(self):
@@ -1385,7 +1385,7 @@ class TestAggregator(unittest.TestCase):
 
         def request(*args, **kwargs):
             return mock.MagicMock(status_code=200, content=TEST_CONTENT)
-        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "/test",
+        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "test",
                                         request=request, expected_return=TEST_CONTENT, prefer_ipv6=True)
 
     def test_send_201_response(self):
@@ -1393,7 +1393,7 @@ class TestAggregator(unittest.TestCase):
 
         def request(*args, **kwargs):
             return mock.MagicMock(status_code=201, content=TEST_CONTENT)
-        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "/test",
+        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "test",
                                         request=request, expected_return=TEST_CONTENT)
 
     def test_send_204_response(self):
@@ -1401,7 +1401,7 @@ class TestAggregator(unittest.TestCase):
 
         def request(*args, **kwargs):
             return mock.MagicMock(status_code=204, content=TEST_CONTENT)
-        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "/test",
+        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "test",
                                         request=request, expected_return=TEST_CONTENT)
 
     def test_send_409_response(self):
@@ -1409,7 +1409,7 @@ class TestAggregator(unittest.TestCase):
 
         def request(*args, **kwargs):
             return mock.MagicMock(status_code=409, content=TEST_CONTENT)
-        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "/test",
+        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "test",
                                         request=request, expected_return=TEST_CONTENT)
 
     def test_send_4xx_response(self):
@@ -1417,28 +1417,28 @@ class TestAggregator(unittest.TestCase):
         apart from 409, which is handled separately"""
         def request(*args, **kwargs):
             return mock.MagicMock(status_code=401)
-        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "/test",
+        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "test",
                                         request=request, expected_exception=InvalidRequest)
 
     def test_send_5xx_response(self):
         """On a 5xx response a ServerSideError Exception should be raised"""
         def request(*args, **kwargs):
             return mock.MagicMock(status_code=500)
-        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "/test",
+        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "test",
                                         request=request, expected_exception=ServerSideError)
 
     def test_send_no_response(self):
         """On a no response a ServerSideError Exception should be raised"""
         def request(*args, **kwargs):
             return None
-        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "/test",
+        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "test",
                                         request=request, expected_exception=ServerSideError)
 
     def test_send_request_exception(self):
         """On a request exception a ServerSideError Exception should be raised"""
         def request(*args, **kwargs):
             raise requests.exceptions.RequestException
-        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "/test",
+        self.assert_send_runs_correctly("POST", "http://www.example.com:80", "v1.2", "test",
                                         request=request, expected_exception=ServerSideError)
 
     # ==================================================================================================================


### PR DESCRIPTION
This is very similar to and closes #48, adding OAuth 2.0 client functionality. The basic auth has been removed until the client registration process has been finalised. A few endpoints have been added to this node's API implementation to enable use of OAuth 2.0, namely:
- `/login` -  this generates the authorization URL on the auth server with all the relevant query parameters (use the FQDN of the host and not localhost if testing otherwise the generated redirect-uri won't be correct)
- `/authorize` - this endpoint corresponds to the registered `redirect_uri` of the client, which the auth code is sent to.

*LITTLE NOTE*: I also (rightly or wrongly) removed the leading slash of the url parameter that is passed into the `_send` function - think my thought process was a function should try and handle things like that as much as possible rather than relying on a particular format of the parameters going into it