### PR TITLE
Mention that python3 is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Package providing a basic NMOS Node API implementation. It takes the form of a "
 ### Requirements
 
 *   Linux (untested on Windows and Mac)
-*   Python 2.7
+*   Python 2.7 (also Python 3.6.9 on Ubuntu 18.04)
 *   Python Pip
 *   [NMOS Common](https://github.com/bbc/nmos-common)
 

--- a/nmosnode/nodefacadeservice.py
+++ b/nmosnode/nodefacadeservice.py
@@ -198,9 +198,9 @@ class NodeFacadeService:
 
     def start(self):
         if self.running:
-            gevent.signal(signal.SIGINT, self.sig_handler)
-            gevent.signal(signal.SIGTERM, self.sig_handler)
-            gevent.signal(signal.SIGHUP, self.sig_hup_handler)
+            gevent.signal_handler(signal.SIGINT, self.sig_handler)
+            gevent.signal_handler(signal.SIGTERM, self.sig_handler)
+            gevent.signal_handler(signal.SIGHUP, self.sig_hup_handler)
 
         self.mdns.start()
         self.node_id = get_node_id()


### PR DESCRIPTION
Python2 is EOL. Python3 on Ubuntu 18.04 (Python 3.6.9) passes tests after some pip3 coercion